### PR TITLE
[Feature] 화이트보드 오브젝트 송수신 설계

### DIFF
--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0080E85B2CE19EBD0095B958 /* DomainStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8582CE19EBD0095B958 /* DomainStruct.swift */; };
 		0080E8BB2CE2ECD80095B958 /* WhiteboardObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8BA2CE2ECC60095B958 /* WhiteboardObject.swift */; };
+		0080E8CE2CE4463B0095B958 /* WhiteboardObjectRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8CD2CE4462E0095B958 /* WhiteboardObjectRepositoryInterface.swift */; };
 		5B7C6EB02CDB6C040024704A /* AirplaINFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EAF2CDB6C040024704A /* AirplaINFoundation.framework */; };
 		5B7C6EB12CDB6C040024704A /* AirplaINFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EAF2CDB6C040024704A /* AirplaINFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -30,6 +31,7 @@
 /* Begin PBXFileReference section */
 		0080E8582CE19EBD0095B958 /* DomainStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainStruct.swift; sourceTree = "<group>"; };
 		0080E8BA2CE2ECC60095B958 /* WhiteboardObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObject.swift; sourceTree = "<group>"; };
+		0080E8CD2CE4462E0095B958 /* WhiteboardObjectRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectRepositoryInterface.swift; sourceTree = "<group>"; };
 		5B7C6E262CDB6A010024704A /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B7C6EAF2CDB6C040024704A /* AirplaINFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AirplaINFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -49,6 +51,7 @@
 		0080E8592CE19EBD0095B958 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				0080E8CB2CE4461F0095B958 /* Interface */,
 				0080E8B92CE2ECB50095B958 /* Entity */,
 				0080E8582CE19EBD0095B958 /* DomainStruct.swift */,
 			);
@@ -69,6 +72,22 @@
 				0080E8BA2CE2ECC60095B958 /* WhiteboardObject.swift */,
 			);
 			path = Entity;
+			sourceTree = "<group>";
+		};
+		0080E8CB2CE4461F0095B958 /* Interface */ = {
+			isa = PBXGroup;
+			children = (
+				0080E8CC2CE446270095B958 /* Repository */,
+			);
+			path = Interface;
+			sourceTree = "<group>";
+		};
+		0080E8CC2CE446270095B958 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				0080E8CD2CE4462E0095B958 /* WhiteboardObjectRepositoryInterface.swift */,
+			);
+			path = Repository;
 			sourceTree = "<group>";
 		};
 		5B7C6E1C2CDB6A010024704A = {
@@ -203,6 +222,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0080E8CE2CE4463B0095B958 /* WhiteboardObjectRepositoryInterface.swift in Sources */,
 				0080E85B2CE19EBD0095B958 /* DomainStruct.swift in Sources */,
 				0080E8BB2CE2ECD80095B958 /* WhiteboardObject.swift in Sources */,
 			);

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -1,0 +1,17 @@
+//
+//  WhiteboardObjectRepositoryInterface.swift
+//  Domain
+//
+//  Created by 이동현 on 11/13/24.
+//
+
+public protocol WhiteboardObjectRepositoryInterface {
+    /// 다른 사람이 보낸 화이트보드 오브젝트를 AsyncStream을 통해 전달하는 메서드
+    /// - Returns: WhiteboardObject들이 담겨 있는 AsyncStream
+    func whiteboardObjectAsyncStream() -> AsyncStream<WhiteboardObject>
+    
+    
+    /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
+    /// - Parameter whiteboardObject: 전송할 Whiteboard Object
+    func send(whiteboardObject: WhiteboardObject)
+}

--- a/Presentation/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation/Presentation.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0080E8C62CE2F0510095B958 /* WhiteboardObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8C52CE2F04F0095B958 /* WhiteboardObjectView.swift */; };
 		0080E8CA2CE2FF750095B958 /* WhiteboardObjectViewFactoryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8C92CE2FF6E0095B958 /* WhiteboardObjectViewFactoryable.swift */; };
+		0080E8D12CE4A00F0095B958 /* WhiteboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */; };
+		0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D22CE4A0820095B958 /* ViewModel.swift */; };
 		5B7C6EBA2CDB6C5C0024704A /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EB92CDB6C5C0024704A /* Domain.framework */; };
 		5B7C6EBB2CDB6C5C0024704A /* Domain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EB92CDB6C5C0024704A /* Domain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A8525DC32CE200230089DA5E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A8525DC22CE200230089DA5E /* Colors.xcassets */; };
@@ -33,6 +35,8 @@
 /* Begin PBXFileReference section */
 		0080E8C52CE2F04F0095B958 /* WhiteboardObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectView.swift; sourceTree = "<group>"; };
 		0080E8C92CE2FF6E0095B958 /* WhiteboardObjectViewFactoryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectViewFactoryable.swift; sourceTree = "<group>"; };
+		0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardViewModel.swift; sourceTree = "<group>"; };
+		0080E8D22CE4A0820095B958 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		5B7C6E502CDB6A380024704A /* Presentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Presentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B7C6EB92CDB6C5C0024704A /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8525DC22CE200230089DA5E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
@@ -75,6 +79,7 @@
 			children = (
 				0080E8C82CE2FF3D0095B958 /* Factory */,
 				0080E8C42CE2F0430095B958 /* View */,
+				0080E8CF2CE49FE90095B958 /* ViewModel */,
 			);
 			path = Whiteboard;
 			sourceTree = "<group>";
@@ -93,6 +98,14 @@
 				0080E8C92CE2FF6E0095B958 /* WhiteboardObjectViewFactoryable.swift */,
 			);
 			path = Factory;
+			sourceTree = "<group>";
+		};
+		0080E8CF2CE49FE90095B958 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		5B7C6E462CDB6A380024704A = {
@@ -131,6 +144,7 @@
 		A8525DC52CE201C00089DA5E /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				0080E8D22CE4A0820095B958 /* ViewModel.swift */,
 				A8525DC92CE202D30089DA5E /* Extension */,
 				A8525DC62CE201CB0089DA5E /* DesignSystem */,
 			);
@@ -262,6 +276,8 @@
 				0080E8C62CE2F0510095B958 /* WhiteboardObjectView.swift in Sources */,
 				A8525DCB2CE203D50089DA5E /* UIView+.swift in Sources */,
 				A8525DC82CE201D50089DA5E /* AirplainFont.swift in Sources */,
+				0080E8D12CE4A00F0095B958 /* WhiteboardViewModel.swift in Sources */,
+				0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */,
 				0080E8CA2CE2FF750095B958 /* WhiteboardObjectViewFactoryable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Presentation/Presentation/Sources/Common/ViewModel.swift
+++ b/Presentation/Presentation/Sources/Common/ViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  ViewModel.swift
+//  Presentation
+//
+//  Created by 이동현 on 11/13/24.
+//
+
+protocol ViewModel {
+    associatedtype Input
+    associatedtype Output
+    
+    func action(input: Input)
+}

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  WhiteboardViewModel.swift
+//  Presentation
+//
+//  Created by 이동현 on 11/13/24.
+//
+
+final class WhiteboardViewModel: ViewModel {
+    enum Input {}
+    struct Output {}
+    
+    func action(input: Input) {
+        
+    }
+}


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 화이트보드 오브젝트를 추가하는 작업을 나누기 전에, 생성한 object를 송수신할 Repository의 인터페이스가 필요했습니다. 이에 딴과 함께 페어프로그래밍을 진행했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 화이트보드 오브젝트 송수신 repository 설계
- ViewModel 프로토콜 정의
- 화이트보드 viewModel 생성

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 비동기 처리에 있어서 Combine보다 Swift Concurrency가 오버헤드가 적을 것이라 생각합니다. 따라서 Combine의 Subject가 아니라, Concurrency의 AsyncStream을 사용하여 설계했습니다.
- 다만 await가 많아지면 Swift Concurrency의 성능이 떨어질 수 있기 때문에 추후 테스트 해보고 Combine으로 구현하는 것을 고려할 필요가 있습니다.
- 구현 가능 여부는 간단하게 [링크](https://buttoned-package-f84.notion.site/5cc4520b0cf64099b293a13b3d86c81e?pvs=4)를 통해 확인했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #75 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- https://developer.apple.com/documentation/swift/asyncsequence
- https://zeddios.tistory.com/1341
- https://zeddios.tistory.com/1339