### PR TITLE
[Feature] 화이트보드에 그림 추가 기능 구현(2차)

### DIFF
--- a/Domain/Domain.xcodeproj/xcshareddata/xcschemes/DomainTests.xcscheme
+++ b/Domain/Domain.xcodeproj/xcshareddata/xcschemes/DomainTests.xcscheme
@@ -54,15 +54,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5B25A3E32CDB68E500CB7B34"
-            BuildableName = "AirplaIN.app"
-            BlueprintName = "AirplaIN"
-            ReferencedContainer = "container:../AirplaIN/AirplaIN.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Domain/Domain/Sources/Entity/DrawingObject.swift
+++ b/Domain/Domain/Sources/Entity/DrawingObject.swift
@@ -8,14 +8,17 @@ import Foundation
 
 public class DrawingObject: WhiteboardObject {
     public private(set) var points: [CGPoint]
+    public let lineWidth: CGFloat
 
     public init(
         id: UUID,
         position: CGPoint,
         size: CGSize,
-        points: [CGPoint]
+        points: [CGPoint],
+        lineWidth: CGFloat
     ) {
         self.points = points
+        self.lineWidth = lineWidth
         super.init(
             id: id,
             position: position,

--- a/Domain/Domain/Sources/Interface/UseCase/DrawObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/DrawObjectUseCaseInterface.swift
@@ -12,15 +12,19 @@ public protocol DrawObjectUseCaseInterface {
     /// 선을 나타내는 점들의 배열
     var points: [CGPoint] { get }
 
-    /// 그리기를 시작하는 메서드
+    /// 선의 굵기를 설정합니다.
+    /// - Parameter width: 선의 너비
+    func setLineWidth(width: CGFloat)
+
+    /// 그리기를 시작합니다.
     /// - Parameter point: 시작 지점 CGPoint
     func startDrawing(at point: CGPoint)
 
-    /// 그림 그리는 중에 새로운 점을 추가하는 메서드
+    /// 그림 그리는 중에 새로운 점을 추가합니다.
     /// - Parameter point: 추가할 점의 CGPoint
     func addPoint(point: CGPoint)
 
-    /// 그림 그리기를 종료하는 메서드
+    /// 그림 그리기를 종료합니다.
     /// - Returns: 완성된 그림 객체 (옵셔널)
     func finishDrawing() -> DrawingObject?
 }

--- a/Domain/Domain/Sources/Interface/UseCase/DrawObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/DrawObjectUseCaseInterface.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 public protocol DrawObjectUseCaseInterface {
-    /// 그림을 그리기 시작한 점
-    var origin: CGPoint? { get }
 
     /// 선을 나타내는 점들의 배열
     var points: [CGPoint] { get }

--- a/Domain/Domain/Sources/Interface/UseCase/DrawObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/DrawObjectUseCaseInterface.swift
@@ -14,7 +14,7 @@ public protocol DrawObjectUseCaseInterface {
 
     /// 선의 굵기를 설정합니다.
     /// - Parameter width: 선의 너비
-    func setLineWidth(width: CGFloat)
+    func configureLineWidth(to width: CGFloat)
 
     /// 그리기를 시작합니다.
     /// - Parameter point: 시작 지점 CGPoint

--- a/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
@@ -20,14 +20,17 @@ public protocol ManageWhiteboardObjectUseCaseInterface {
     /// 화이트보드 객체를 추가하는 메서드
     /// - Parameter whiteboardObject: 추가할 화이트보드 객체
     /// - Returns: 추가 성공 여부
+    @discardableResult
     func addObject(whiteboardObject: WhiteboardObject) -> Bool
 
     /// 화이트보드 객체를 수정하는 메서드
     /// - Parameter whiteboardObject: 수정할 화이트보드 객체
     /// - Returns: 추가 성공 여부
+    @discardableResult
     func updateObject(whiteboardObject: WhiteboardObject) -> Bool
 
     /// 화이트보드를 제거하는 메서드
     /// - Returns: 추가 성공 여부
+    @discardableResult
     func removeObject(whiteboardObject: WhiteboardObject) -> Bool
 }

--- a/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
@@ -9,10 +9,15 @@ import Foundation
 
 public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
     public private(set) var points: [CGPoint]
-//    public private(set) var origin: CGPoint?
+    public private(set) var lineWidth: CGFloat
 
     public init() {
         points = []
+        lineWidth = 5
+    }
+
+    public func setLineWidth(width: CGFloat) {
+        lineWidth = width
     }
 
     public func startDrawing(at point: CGPoint) {
@@ -36,18 +41,19 @@ public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
             let minY = yPoints.min(),
             let maxY = yPoints.max()
         else { return nil }
-
-        let origin = CGPoint(x: minX, y: minY)
-        let size = CGSize(width: maxX - minX, height: maxY - minY)
+        let padding = lineWidth / 2
+        let origin = CGPoint(x: minX - padding, y: minY - padding)
+        let size = CGSize(width: maxX - minX + padding * 2, height: maxY - minY + padding * 2)
         let adjustedPoints = points.map {
-            CGPoint(x: $0.x - minX, y: $0.y - minY)
+            CGPoint(x: $0.x - minX + padding, y: $0.y - minY + padding)
         }
 
         let drawingObject = DrawingObject(
             id: UUID(),
             position: origin,
             size: size,
-            points: adjustedPoints)
+            points: adjustedPoints,
+            lineWidth: lineWidth)
 
         return drawingObject
     }

--- a/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
@@ -9,14 +9,13 @@ import Foundation
 
 public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
     public private(set) var points: [CGPoint]
-    public private(set) var origin: CGPoint?
+//    public private(set) var origin: CGPoint?
 
     public init() {
         points = []
     }
 
     public func startDrawing(at point: CGPoint) {
-        origin = point
         points = [point]
     }
 
@@ -32,13 +31,13 @@ public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
         }
 
         guard
-            let origin,
             let minX = xPoints.min(),
             let maxX = xPoints.max(),
             let minY = yPoints.min(),
             let maxY = yPoints.max()
         else { return nil }
 
+        let origin = CGPoint(x: minX, y: minY)
         let size = CGSize(width: maxX - minX, height: maxY - minY)
         let adjustedPoints = points.map {
             CGPoint(x: $0.x - minX, y: $0.y - minY)
@@ -54,7 +53,6 @@ public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
     }
 
     private func reset() {
-        origin = nil
         points.removeAll()
     }
 }

--- a/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
@@ -16,7 +16,7 @@ public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
         lineWidth = 5
     }
 
-    public func setLineWidth(width: CGFloat) {
+    public func configureLineWidth(to width: CGFloat) {
         lineWidth = width
     }
 

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardToolUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardToolUseCase.swift
@@ -21,12 +21,8 @@ public final class ManageWhiteboardToolUseCase: ManageWhiteboardToolUseCaseInter
     }
 
     public func selectTool(tool: WhiteboardTool) {
-        let previousTool = currentToolSubject.value
-        if previousTool == tool {
-            currentToolSubject.send(nil)
-        } else {
-            currentToolSubject.send(tool)
-        }
+        let selectTool = currentToolSubject.value == tool ? nil: tool
+        currentToolSubject.send(selectTool)
     }
 
     public func finishUsingTool() {

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardToolUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardToolUseCase.swift
@@ -21,7 +21,12 @@ public final class ManageWhiteboardToolUseCase: ManageWhiteboardToolUseCaseInter
     }
 
     public func selectTool(tool: WhiteboardTool) {
-        currentToolSubject.send(tool)
+        let previousTool = currentToolSubject.value
+        if previousTool == tool {
+            currentToolSubject.send(nil)
+        } else {
+            currentToolSubject.send(tool)
+        }
     }
 
     public func finishUsingTool() {

--- a/Domain/DomainTests/DrawObjectUseCaseTests.swift
+++ b/Domain/DomainTests/DrawObjectUseCaseTests.swift
@@ -8,71 +8,69 @@ import Domain
 import XCTest
 
 final class DrawObjectUseCaseTests: XCTestCase {
+    let lineWidth: CGFloat = 1
     var useCase: DrawObjectUseCaseInterface!
 
     override func setUpWithError() throws {
         useCase = DrawObjectUseCase()
+        useCase.setLineWidth(width: lineWidth)
     }
 
     override func tearDownWithError() throws {
         useCase = nil
     }
-
+    
     // 그림을 그릴 때, points 배열에 점들을 올바르게 추가하는지 확인
     func testAddPointToArray() {
+        // 준비
         let startPoint = CGPoint(x: 100, y: 100)
         let point1 = CGPoint(x: 115, y: 115)
         let point2 = CGPoint(x: 15, y: 30)
 
+        // 실행
         useCase.startDrawing(at: startPoint)
         useCase.addPoint(point: point1)
         useCase.addPoint(point: point2)
 
+        // 검증
         XCTAssertEqual(useCase.points, [startPoint, point1, point2])
     }
 
     // finishDrawing이 올바르게 DrawingObject를 생성하는지 확인
      func testFinishDrawingCreatesAndSendsDrawingObject() {
+         // 준비
          useCase.startDrawing(at: CGPoint(x: 10, y: 10))
          useCase.addPoint(point: CGPoint(x: 11, y: 11))
          useCase.addPoint(point: CGPoint(x: 12, y: 12))
          useCase.addPoint(point: CGPoint(x: 13, y: 13))
+         let padding = lineWidth / 2
+         let expectedAdjustedPoints = [
+             CGPoint(x: 0 + padding, y: 0 + padding),
+             CGPoint(x: 1 + padding, y: 1 + padding),
+             CGPoint(x: 2 + padding, y: 2 + padding),
+             CGPoint(x: 3 + padding, y: 3 + padding)]
 
+         // 실행
          let drawingObject = useCase.finishDrawing()
 
+         // 검증
          XCTAssertNotNil(drawingObject)
-         XCTAssertEqual(drawingObject?.position, CGPoint(x: 10, y: 10))
-         XCTAssertEqual(drawingObject?.size, CGSize(width: 3, height: 3))
-
-         let expectedAdjustedPoints = [
-             CGPoint(x: 0, y: 0),
-             CGPoint(x: 1, y: 1),
-             CGPoint(x: 2, y: 2),
-             CGPoint(x: 3, y: 3)]
+         XCTAssertEqual(drawingObject?.position, CGPoint(x: 10 - padding, y: 10 - padding))
+         XCTAssertEqual(drawingObject?.size, CGSize(width: 3 + padding * 2, height: 3 + padding * 2))
          XCTAssertEqual(drawingObject?.points, expectedAdjustedPoints)
      }
 
     // 그림 그린 후 useCase 내부 상태 초기화가 되는지 확인
     func testResetAfterFinishDrawing() {
+        // 준비
         useCase.startDrawing(at: CGPoint(x: 10, y: 10))
         useCase.addPoint(point: CGPoint(x: 110, y: 110))
         useCase.addPoint(point: CGPoint(x: 120, y: 120))
+
+        // 실행
         _ = useCase.finishDrawing()
 
+        // 검증
         XCTAssertEqual(useCase.points.count, 0)
-    }
-}
-
-final class MockWhiteboardObjectRepository: WhiteboardObjectRepositoryInterface {
-    private var continuation: AsyncStream<WhiteboardObject>.Continuation?
-
-    func send(whiteboardObject: WhiteboardObject) {
-        continuation?.yield(whiteboardObject)
-    }
-
-    func whiteboardObjectAsyncStream() -> AsyncStream<WhiteboardObject> {
-        return AsyncStream { continuation in
-            self.continuation = continuation
-        }
     }
 }

--- a/Domain/DomainTests/DrawObjectUseCaseTests.swift
+++ b/Domain/DomainTests/DrawObjectUseCaseTests.swift
@@ -18,14 +18,6 @@ final class DrawObjectUseCaseTests: XCTestCase {
         useCase = nil
     }
 
-    // startDrawing시, 시작 좌표를 올바르게 설정하는지 확인
-    func testStartDrawingSetsOrigin() {
-        let startPoint = CGPoint(x: 100, y: 100)
-        useCase.startDrawing(at: startPoint)
-
-        XCTAssertEqual(startPoint, useCase.origin)
-    }
-
     // 그림을 그릴 때, points 배열에 점들을 올바르게 추가하는지 확인
     func testAddPointToArray() {
         let startPoint = CGPoint(x: 100, y: 100)
@@ -67,7 +59,6 @@ final class DrawObjectUseCaseTests: XCTestCase {
         useCase.addPoint(point: CGPoint(x: 120, y: 120))
         _ = useCase.finishDrawing()
 
-        XCTAssertNil(useCase.origin)
         XCTAssertEqual(useCase.points.count, 0)
     }
 }

--- a/Domain/DomainTests/DrawObjectUseCaseTests.swift
+++ b/Domain/DomainTests/DrawObjectUseCaseTests.swift
@@ -13,13 +13,13 @@ final class DrawObjectUseCaseTests: XCTestCase {
 
     override func setUpWithError() throws {
         useCase = DrawObjectUseCase()
-        useCase.setLineWidth(width: lineWidth)
+        useCase.configureLineWidth(to: lineWidth)
     }
 
     override func tearDownWithError() throws {
         useCase = nil
     }
-    
+
     // 그림을 그릴 때, points 배열에 점들을 올바르게 추가하는지 확인
     func testAddPointToArray() {
         // 준비

--- a/Presentation/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation/Presentation.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0080E8D12CE4A00F0095B958 /* WhiteboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */; };
 		0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D22CE4A0820095B958 /* ViewModel.swift */; };
 		00CCC2672CE60BCD005FA747 /* AirplainFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8525DC72CE201D50089DA5E /* AirplainFont.swift */; };
+		00D2DD982CE8CD300089F0BA /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D2DD972CE8CD300089F0BA /* DrawingView.swift */; };
 		5B2BC78E2CE4F66F00893B9E /* WhiteboardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2BC78A2CE4F66F00893B9E /* WhiteboardListViewController.swift */; };
 		5B2BC78F2CE4F66F00893B9E /* WhiteboardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2BC78C2CE4F66F00893B9E /* WhiteboardListViewModel.swift */; };
 		5B7C6EBA2CDB6C5C0024704A /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EB92CDB6C5C0024704A /* Domain.framework */; };
@@ -51,6 +52,7 @@
 		0080E8C92CE2FF6E0095B958 /* WhiteboardObjectViewFactoryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectViewFactoryable.swift; sourceTree = "<group>"; };
 		0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardViewModel.swift; sourceTree = "<group>"; };
 		0080E8D22CE4A0820095B958 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		00D2DD972CE8CD300089F0BA /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
 		5B2BC78A2CE4F66F00893B9E /* WhiteboardListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardListViewController.swift; sourceTree = "<group>"; };
 		5B2BC78C2CE4F66F00893B9E /* WhiteboardListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardListViewModel.swift; sourceTree = "<group>"; };
 		5B7C6E502CDB6A380024704A /* Presentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Presentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -135,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				6F199EF22CE3203A005DC40F /* WhiteboardViewController.swift */,
+				00D2DD972CE8CD300089F0BA /* DrawingView.swift */,
 				004645F22CE60A1B00C76EDB /* ObjectView */,
 			);
 			path = View;
@@ -383,6 +386,7 @@
 				A8E97ABF2CE4E94D00B28063 /* SelectProfileIconViewController.swift in Sources */,
 				A8E979C52CE493E900B28063 /* ProfileViewController.swift in Sources */,
 				A85260252CE3447E0089DA5E /* UIColor+.swift in Sources */,
+				00D2DD982CE8CD300089F0BA /* DrawingView.swift in Sources */,
 				A8E979CA2CE49A1800B28063 /* ProfileViewModel.swift in Sources */,
 				0080E8C62CE2F0510095B958 /* WhiteboardObjectView.swift in Sources */,
 				A8525DCB2CE203D50089DA5E /* UIView+.swift in Sources */,

--- a/Presentation/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation/Presentation.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D22CE4A0820095B958 /* ViewModel.swift */; };
 		00CCC2672CE60BCD005FA747 /* AirplainFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8525DC72CE201D50089DA5E /* AirplainFont.swift */; };
 		00D2DD982CE8CD300089F0BA /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D2DD972CE8CD300089F0BA /* DrawingView.swift */; };
+		00D2DD9A2CE8DCEA0089F0BA /* DrawingObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D2DD992CE8DCEA0089F0BA /* DrawingObjectView.swift */; };
 		5B2BC78E2CE4F66F00893B9E /* WhiteboardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2BC78A2CE4F66F00893B9E /* WhiteboardListViewController.swift */; };
 		5B2BC78F2CE4F66F00893B9E /* WhiteboardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2BC78C2CE4F66F00893B9E /* WhiteboardListViewModel.swift */; };
 		5B7C6EBA2CDB6C5C0024704A /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EB92CDB6C5C0024704A /* Domain.framework */; };
@@ -53,6 +54,7 @@
 		0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardViewModel.swift; sourceTree = "<group>"; };
 		0080E8D22CE4A0820095B958 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		00D2DD972CE8CD300089F0BA /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
+		00D2DD992CE8DCEA0089F0BA /* DrawingObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingObjectView.swift; sourceTree = "<group>"; };
 		5B2BC78A2CE4F66F00893B9E /* WhiteboardListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardListViewController.swift; sourceTree = "<group>"; };
 		5B2BC78C2CE4F66F00893B9E /* WhiteboardListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardListViewModel.swift; sourceTree = "<group>"; };
 		5B7C6E502CDB6A380024704A /* Presentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Presentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -90,6 +92,7 @@
 				0080E8C52CE2F04F0095B958 /* WhiteboardObjectView.swift */,
 				6F199EF02CE31A05005DC40F /* WhiteboardToolBar.swift */,
 				6F21477C2CE4EFCF00B55E2C /* TextObjectView.swift */,
+				00D2DD992CE8DCEA0089F0BA /* DrawingObjectView.swift */,
 			);
 			path = ObjectView;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 				6F199EF32CE3203A005DC40F /* WhiteboardViewController.swift in Sources */,
 				6F199EF12CE31A05005DC40F /* WhiteboardToolBar.swift in Sources */,
 				6F21477D2CE4EFCF00B55E2C /* TextObjectView.swift in Sources */,
+				00D2DD9A2CE8DCEA0089F0BA /* DrawingObjectView.swift in Sources */,
 				0080E8D12CE4A00F0095B958 /* WhiteboardViewModel.swift in Sources */,
 				0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */,
 				5B2BC78E2CE4F66F00893B9E /* WhiteboardListViewController.swift in Sources */,

--- a/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
@@ -8,15 +8,16 @@ import Domain
 import Foundation
 
 protocol WhiteboardObjectViewFactoryable {
-    func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView
+    func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView?
 }
 
 struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
-    func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView {
+    func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView? {
         switch whiteboardObject {
         case let textObject as TextObject:
             return TextObjectView(textObject: textObject)
-        // TODO: 오브젝트 별 case 추가 예정
+        case let drawingObject as DrawingObject:
+            return DrawingObjectView(drawingObject: drawingObject)
         default:
             break
         }

--- a/Presentation/Presentation/Sources/Whiteboard/Util/DrawingRenderer.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Util/DrawingRenderer.swift
@@ -17,7 +17,8 @@ struct DrawingRenderer: DrawingRendererInterface {
 
         let renderer = UIGraphicsImageRenderer(size: drawingObject.size)
         let image = renderer.image { context in
-            context.cgContext.setLineWidth(5)
+            context.cgContext.setLineCap(.round)
+            context.cgContext.setLineWidth(drawingObject.lineWidth)
             context.cgContext.setStrokeColor(UIColor.black.cgColor)
             context.cgContext.move(to: startPoint)
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
@@ -1,0 +1,89 @@
+//
+//  DrawingView.swift
+//  Presentation
+//
+//  Created by 이동현 on 11/16/24.
+//
+
+import UIKit
+
+protocol DrawingViewDelegate: AnyObject {
+    func drawingView(_ sender: DrawingView, at point: CGPoint)
+    func drawingViewDidStartDrawing(_ sender: DrawingView, at point: CGPoint)
+    func drawingViewDidEndDrawing(_ sender: DrawingView)
+}
+
+final class DrawingView: UIView {
+    private let currentDrawingImageView = UIImageView()
+    private var imageRenderer: UIGraphicsImageRenderer?
+    private var previousPoint: CGPoint?
+    weak var delegate: DrawingViewDelegate?
+
+    init() {
+        super.init(frame: .zero)
+        configureAttributes()
+        configureLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureAttributes()
+        configureLayout()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        imageRenderer = UIGraphicsImageRenderer(bounds: bounds)
+    }
+
+    private func configureAttributes() {
+        let drawingGesture = UIPanGestureRecognizer(target: self, action: #selector(handleDrawingGesture(sender:)))
+        drawingGesture.minimumNumberOfTouches = 1
+        drawingGesture.maximumNumberOfTouches = 1
+        self.addGestureRecognizer(drawingGesture)
+    }
+
+    private func configureLayout() {
+        currentDrawingImageView
+            .addToSuperview(self)
+            .edges(equalTo: self)
+    }
+
+    @objc private func handleDrawingGesture(sender: UIPanGestureRecognizer) {
+        let point = sender.location(in: self)
+        
+        switch sender.state {
+        case .began:
+            delegate?.drawingViewDidStartDrawing(self, at: point)
+            renderDrawing(at: point)
+        case .changed:
+            delegate?.drawingView(self, at: point)
+            renderDrawing(at: point)
+        case .ended:
+            delegate?.drawingViewDidEndDrawing(self)
+            previousPoint = nil
+        default:
+            break
+        }
+    }
+
+    private func renderDrawing(at point: CGPoint) {
+
+        let drawingImage: UIImage? = imageRenderer?.image { context in
+
+            currentDrawingImageView
+                .image?
+                .draw(in: currentDrawingImageView.bounds)
+            context.cgContext.setLineWidth(5)
+            context.cgContext.setStrokeColor(UIColor.black.cgColor)
+
+            if let previousPoint {
+                context.cgContext.move(to: previousPoint)
+                context.cgContext.addLine(to: point)
+                context.cgContext.strokePath()
+            }
+        }
+        currentDrawingImageView.image = drawingImage
+        previousPoint = point
+    }
+}

--- a/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
@@ -14,8 +14,8 @@ protocol DrawingViewDelegate: AnyObject {
 }
 
 final class DrawingView: UIView {
-    private var drawingLayer = CAShapeLayer()
-    private var drawingPath = UIBezierPath()
+    private let drawingLayer = CAShapeLayer()
+    private let drawingPath = UIBezierPath()
     private var previousPoint: CGPoint?
     weak var delegate: DrawingViewDelegate?
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
@@ -36,6 +36,7 @@ final class DrawingView: UIView {
     }
 
     private func configureAttributes() {
+        backgroundColor = .clear
         drawingLayer.strokeColor = UIColor.black.cgColor
         drawingLayer.lineWidth = 5
         drawingLayer.lineCap = .round

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
@@ -1,0 +1,8 @@
+//
+//  DrawingObjectView.swift
+//  Presentation
+//
+//  Created by 이동현 on 11/16/24.
+//
+
+import Foundation

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
@@ -5,4 +5,36 @@
 //  Created by 이동현 on 11/16/24.
 //
 
-import Foundation
+import Domain
+import UIKit
+
+final class DrawingObjectView: WhiteboardObjectView {
+    let imageView = UIImageView()
+    // TODO: - 딴과 논의 필요
+    let objectId: UUID
+
+    init(drawingObject: DrawingObject) {
+        self.objectId = drawingObject.id
+        super.init(whiteboardObject: drawingObject)
+
+        configureLayout()
+        renderImage(with: drawingObject)
+    }
+
+    required init?(coder: NSCoder) {
+        objectId = UUID()
+        super.init(coder: coder)
+    }
+
+    private func configureLayout() {
+        imageView
+            .addToSuperview(self)
+            .edges(equalTo: self)
+    }
+
+    private func renderImage(with object: DrawingObject) {
+        let renderer = DrawingRenderer()
+        let renderedImage = renderer.render(drawingObject: object)
+        imageView.image = renderedImage
+    }
+}

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardToolBar.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardToolBar.swift
@@ -13,6 +13,10 @@ protocol WhiteboardToolBarDelegate: AnyObject {
 }
 
 final class WhiteboardToolBar: UIStackView {
+    private enum WhiteboardToolBarLayoutConstant {
+        static let toolbarSpacing: CGFloat = 30
+    }
+
     private let drawing = UIButton()
     private let text = UIButton()
     private let photo = UIButton()
@@ -45,7 +49,7 @@ final class WhiteboardToolBar: UIStackView {
 
     private func configureAttribute() {
         distribution = .fillEqually
-        spacing = 30
+        spacing = WhiteboardToolBarLayoutConstant.toolbarSpacing
     }
 
     private func configureButtons() {

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardToolBar.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardToolBar.swift
@@ -5,7 +5,6 @@
 //  Created by 박승찬 on 11/12/24.
 //
 
-import Combine
 import Domain
 import UIKit
 
@@ -20,8 +19,6 @@ final class WhiteboardToolBar: UIStackView {
     private let game = UIButton()
     private let chat = UIButton()
     private var tools: [WhiteboardTool: UIButton] = [:]
-    private var selectedTool = CurrentValueSubject<WhiteboardTool?, Never>(nil)
-    private var cancellables: Set<AnyCancellable> = []
     weak var delegate: WhiteboardToolBarDelegate?
 
     override init(frame: CGRect) {
@@ -37,11 +34,13 @@ final class WhiteboardToolBar: UIStackView {
     private func initialize() {
         configureAttribute()
         configureButtons()
-        bind()
     }
 
-    func done() {
+    func select(tool: WhiteboardTool?) {
         tools.forEach { $1.setImage($0.defaultIcon, for: .normal) }
+        if let tool {
+            tools[tool]?.setImage(tool.selectedIcon, for: .normal)
+        }
     }
 
     private func configureAttribute() {
@@ -54,30 +53,15 @@ final class WhiteboardToolBar: UIStackView {
         zip(WhiteboardTool.allCases, buttons).forEach { whiteboardTool, button in
             tools[whiteboardTool] = button
             addArrangedSubview(button)
+            button.setImage(whiteboardTool.defaultIcon, for: .normal)
             button.tintColor = .airplainBlue
             button.addAction(
                 UIAction { [weak self] _ in
                     guard let self else { return }
-                    guard whiteboardTool != selectedTool.value else {
-                        done()
-                        return
-                    }
                     self.delegate?.whiteboardToolBar(self, selectedTool: whiteboardTool)
-                    self.selectedTool.send(whiteboardTool)
                 },
                 for: .touchUpInside )
         }
-    }
-
-    private func bind() {
-        selectedTool
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] tool in
-                self?.done()
-                guard let tool else { return }
-                self?.tools[tool]?.setImage(tool.selectedIcon, for: .normal)
-            }
-            .store(in: &cancellables)
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -5,47 +5,120 @@
 //  Created by 박승찬 on 11/12/24.
 //
 
+import Combine
 import Domain
 import UIKit
 
 public class WhiteboardViewController: UIViewController {
+    // TODO: - indicator 표시 여부 논의 필요
+    private let scrollView = UIScrollView()
+    private let drawingView = DrawingView()
+    private let canvasView = UIView()
     private let toolbar = WhiteboardToolBar(frame: .zero)
+    private let viewModel: WhiteboardViewModel
+    private var cancellables: Set<AnyCancellable>
+
+    init(viewModel: WhiteboardViewModel) {
+        self.viewModel = viewModel
+        cancellables = []
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("WhiteboardViewController 초기화 오류")
+    }
 
     public override func viewDidLoad() {
         super.viewDidLoad()
         configureAttribute()
         configureLayout()
+        bind()
+        drawingView.backgroundColor = .gray
     }
 
     private func configureAttribute() {
         view.backgroundColor = .systemBackground
+        drawingView.isHidden = true
         toolbar.delegate = self
+        drawingView.delegate = self
     }
 
     private func configureLayout() {
+        scrollView
+            .addToSuperview(view)
+            .top(equalTo: view.safeAreaLayoutGuide.topAnchor, inset: .zero)
+            .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor, inset: .zero)
+            .horizontalEdges(equalTo: view)
+
+        canvasView
+            .addToSuperview(scrollView)
+            .top(equalTo: scrollView.contentLayoutGuide.topAnchor, inset: .zero)
+            .bottom(equalTo: scrollView.contentLayoutGuide.bottomAnchor, inset: .zero)
+            .leading(equalTo: scrollView.contentLayoutGuide.leadingAnchor, inset: .zero)
+            .trailing(equalTo: scrollView.contentLayoutGuide.trailingAnchor, inset: .zero)
+            .size(width: 1500, height: 1500)
+
+        drawingView
+            .addToSuperview(scrollView)
+            .edges(equalTo: canvasView)
+
         toolbar
             .addToSuperview(view)
             .horizontalEdges(equalTo: view, inset: 22)
             .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor, inset: 0)
             .height(equalTo: 40)
     }
+
+    private func bind() {
+        viewModel.output.whiteboardToolPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] tool in
+                self?.toolbar.select(tool: tool)
+                self?.drawingView.isHidden = tool != .drawing
+                self?.scrollView.panGestureRecognizer.minimumNumberOfTouches = tool == .drawing ? 2 : 1
+            }
+            .store(in: &cancellables)
+
+        viewModel.output.addedWhiteboardObjectPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+
+            }
+            .store(in: &cancellables)
+
+        viewModel.output.updatedWhiteboardObjectPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                // TODO: - 오브젝트 수정 시 동작 구현
+            }
+            .store(in: &cancellables)
+
+        viewModel.output.removedWhiteboardObjectPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                // TODO: - 오브젝트 삭제 시 동작 구현
+            }
+            .store(in: &cancellables)
+    }
 }
 
 // MARK: - WhiteboardToolBarDelegate
 extension WhiteboardViewController: WhiteboardToolBarDelegate {
     func whiteboardToolBar(_ sender: WhiteboardToolBar, selectedTool: WhiteboardTool) {
-        // TODO: 각 Tool에 따른 실행 동작 구현
-        switch selectedTool {
-        case .drawing:
-            break
-        case .text:
-            break
-        case .photo:
-            break
-        case .game:
-            break
-        case .chat:
-            break
-        }
+        viewModel.action(input: .selectTool(tool: selectedTool))
+    }
+}
+
+extension WhiteboardViewController: DrawingViewDelegate {
+    func drawingView(_ sender: DrawingView, at point: CGPoint) {
+        viewModel.action(input: .startDrawing(startAt: point))
+    }
+
+    func drawingViewDidStartDrawing(_ sender: DrawingView, at point: CGPoint) {
+        viewModel.action(input: .addDrawingPoint(point: point))
+    }
+
+    func drawingViewDidEndDrawing(_ sender: DrawingView) {
+        viewModel.action(input: .finishDrawing)
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -10,6 +10,11 @@ import Domain
 import UIKit
 
 public class WhiteboardViewController: UIViewController {
+    private enum WhiteboardLayoutConstant {
+        static let canvaseSize: CGFloat = 1500
+        static let toolbarHeight: CGFloat = 40
+    }
+
     // TODO: - indicator 표시 여부 논의 필요
     private let scrollView = UIScrollView()
     private let drawingView = DrawingView()
@@ -57,7 +62,9 @@ public class WhiteboardViewController: UIViewController {
             .bottom(equalTo: scrollView.contentLayoutGuide.bottomAnchor, inset: .zero)
             .leading(equalTo: scrollView.contentLayoutGuide.leadingAnchor, inset: .zero)
             .trailing(equalTo: scrollView.contentLayoutGuide.trailingAnchor, inset: .zero)
-            .size(width: 1500, height: 1500)
+            .size(
+                width: WhiteboardLayoutConstant.canvaseSize,
+                height: WhiteboardLayoutConstant.canvaseSize)
 
         drawingView
             .addToSuperview(scrollView)
@@ -65,9 +72,9 @@ public class WhiteboardViewController: UIViewController {
 
         toolbar
             .addToSuperview(view)
-            .horizontalEdges(equalTo: view, inset: 22)
-            .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor, inset: 0)
-            .height(equalTo: 40)
+            .horizontalEdges(equalTo: view, inset: horizontalMargin)
+            .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor, inset: .zero)
+            .height(equalTo: WhiteboardLayoutConstant.toolbarHeight)
     }
 
     private func bind() {

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -96,11 +96,8 @@ public final class WhiteboardListViewController: UIViewController {
     private func bind() {
         viewModel.output.whiteboardPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { _ in
                 // TODO: 화이트보드 추가
-                let whiteboardViewController = WhiteboardViewController()
-                whiteboardViewController.modalPresentationStyle = .fullScreen
-                self?.present(whiteboardViewController, animated: true)
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 저번 PR에서는 그림그리기에 대한 도메인 작업을 완료했습니다. (https://github.com/boostcampwm-2024/iOS02-AirplaIN/pull/77)
- 이번 PR에서는 도메인과 view를 연결하는 작업을 진행했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- iPhone SE3

https://github.com/user-attachments/assets/deb2fdc7-f80d-4525-8f6a-1273d317b498

- iPhone 13 mini

https://github.com/user-attachments/assets/c72b3cf5-a5b0-410e-b48e-81420e0a544c

- iPhone 16 Pro 

https://github.com/user-attachments/assets/42c414d3-4cf7-4580-8aa2-b7871406949e


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 화이트 보드 뷰 구현 (화이트 보드 크기는 임시로 1500 * 1500으로 설정했습니다.)
- ToolBarUI의 작동 방식 수정
- 그림 그리기 기능 완성

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- WhiteboardViewController를 생성하고, toolBar에서 연필 버튼을 누르면 테스트 할 수 있습니다.
- 그림 그리기 기능이 활성화되면 스크롤 뷰는 두 손가락으로 이동 가능합니다.
- 그림 그리기 기능이 비활성화되어 있다면 한 손가락으로 스크롤 뷰 이동이 가능합니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### toolBar의 작동 방식 수정  (커밋 링크: bee7bef434a9999c82a1957a12e54d3053bf0aa0)
- 기존에는 toolBar에서 어떤 도구가 선택되었는지 관리했습니다.
- 툴 바를 관리하는 유즈케이스가 새로 생김에 따라서 해당 로직을 toolBar에서 삭제했습니다.
- viewModel에서 전달해주는 상태에 따라 toolBar UI를 업데이트 하도록 수정했습니다.

### 그림 오브젝트 생성 전 실시간 그림 그리기 (커밋 링크: 13873ec7854a29bf18000393fab68d9a969fbb0d, d9509f5ca9717bffd97dd284bce1830f2d87e3db)
- 사용자가 그린 그림을 화이트보드에 추가하기 전에 그린 그림의 모습을 실시간으로 보여줘야 합니다.
- 처음 구현한 방식은, 학습 스프린트에서 진행했던 방식을 차용했습니다.
- 그림에 점이 추가될 때마다 UIGraphicsImageRenderer를 통해 새로운 이미지를 생성한 후, 이를 화면에 표시해주었습니다.
- 점이 추가될 때마다 새로운 이미지를 렌더링 해야해서 반응성이 굉장히 좋지 않았고, 성능 저하 가능성이 커보였습니다.
- 이미지 렌더러로 실시간 이미지 생성이 아닌, CAShapeLayer를 이용해서 추가되는 선들을 직접 layer에 추가하는 방식으로 개선했습니다.

### UIGraphicsImageRenderer로 이미지를 렌더링 하면 네 모서리쪽 선들이 잘리는 현상 (커밋 링크: 6457079836390afa4465f956a217a5efebfcb7b1)
- 스프린트 때도 같은 문제로 삽질 했으나, 당시에는 흐린눈으로 지나갔던 문제입니다.
- 그림 그리는 선의 너비가 x라면, 모서리에 딱 붙어있는 선들은 x / 2 만큼 잘려서 렌더링되지 않는 문제가 있습니다.
- 그림 그릴 때, 추가한 점을 중심으로 지름이 x인 원으로 점을 표시하기 때문에 발생하는 문제입니다. 
- 아래 과정을 통해 문제를 해결할 수 있었습니다.
    - 실제 그린 그림의 너비와 높이에 선의 너비만큼 더해주어 그림 object size를 설정했습니다.
    - 그림을 그린 점들의 x, y 좌표에 (선의 너비 / 2) 만큼 더해주었습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #9 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
