### PR TITLE
[Feature] Whiteboard를 advertising 할 때 참여자 정보 담아서 보내는 로직 구현

### DIFF
--- a/AirplaIN/AirplaIN/SceneDelegate.swift
+++ b/AirplaIN/AirplaIN/SceneDelegate.swift
@@ -8,6 +8,7 @@
 import DataSource
 import Domain
 import NearbyNetwork
+import Persistence
 import Presentation
 import UIKit
 
@@ -23,8 +24,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // TODO: - 임시 의존성 주입
         let nearbyNetworkService = NearbyNetworkService(profileName: "name", serviceName: "whiteboard")
+        let profileRepository = ProfileRepository(persistenceService: PersistenceService())
+        let profileUseCase = ProfileUseCase(repository: profileRepository)
+        let profile = profileRepository.loadProfile()
         let repository = WhiteboardRepository(nearbyNetworkInterface: nearbyNetworkService)
-        let whiteboardUseCase = WhiteboardUseCase(repository: repository)
+        let whiteboardUseCase = WhiteboardUseCase(repository: repository, profile: profile)
         let viewModel = WhiteboardListViewModel(whiteboardUseCase: whiteboardUseCase, nickname: "name")
         let viewController = WhiteboardListViewController(viewModel: viewModel)
 

--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -19,6 +19,10 @@ public protocol NearbyNetworkInterface {
     /// 주변에 내 기기를 알립니다.
     func startPublishing()
 
+    /// 주변에 내 기기를 정보와 함께 알립니다.
+    /// - Parameter data: 담을 정보
+    func startPublishing(with info: [String: String])
+
     /// 주변에 내 기기 알리는 것을 중지합니다.
     func stopPublishing()
 

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -16,8 +16,10 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         self.nearbyNetwork.delegate = self
     }
 
-    public func startPublishing(with info: [String]) {
-        let participantsInfo: [String: String] = ["participants": info.joined(separator: ",")]
+    public func startPublishing(with info: [Profile]) {
+        let participantsInfo: [String: String] = ["participants": info
+            .compactMap { $0.profileIcon.emoji }
+            .joined(separator: ",")]
         nearbyNetwork.startPublishing(with: participantsInfo)
     }
 }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -16,8 +16,8 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         self.nearbyNetwork.delegate = self
     }
 
-    public func startPublishing() {
-        nearbyNetwork.startPublishing()
+    public func startPublishing(with info: [String: String]) {
+        nearbyNetwork.startPublishing(with: info)
     }
 }
 

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -16,8 +16,9 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         self.nearbyNetwork.delegate = self
     }
 
-    public func startPublishing(with info: [String: String]) {
-        nearbyNetwork.startPublishing(with: info)
+    public func startPublishing(with info: [String]) {
+        let participantsInfo: [String: String] = ["participants": info.joined(separator: ",")]
+        nearbyNetwork.startPublishing(with: participantsInfo)
     }
 }
 

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -6,6 +6,6 @@
 //
 
 public protocol WhiteboardRepositoryInterface {
-    /// 화이트보드를 주변에 알립니다.
-    func startPublishing()
+    /// 주변에 내 기기를 정보와 함께 화이트보드를 알립니다.
+    func startPublishing(with info: [String: String])
 }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -7,5 +7,5 @@
 
 public protocol WhiteboardRepositoryInterface {
     /// 주변에 내 기기를 참여자의 아이콘 정보와 함께 화이트보드를 알립니다.
-    func startPublishing(with info: [String])
+    func startPublishing(with info: [Profile])
 }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -6,6 +6,6 @@
 //
 
 public protocol WhiteboardRepositoryInterface {
-    /// 주변에 내 기기를 정보와 함께 화이트보드를 알립니다.
-    func startPublishing(with info: [String: String])
+    /// 주변에 내 기기를 참여자의 아이콘 정보와 함께 화이트보드를 알립니다.
+    func startPublishing(with info: [String])
 }

--- a/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
@@ -10,6 +10,6 @@ public protocol WhiteboardUseCaseInterface {
     /// - Parameter nickname: 유저 닉네임(화이트보드의 이름으로 사용)
     func createWhiteboard(nickname: String) -> Whiteboard
 
-    /// 화이트보드를 주변에 알립니다. 
+    /// 주변에 내 기기를 정보와 함께 알립니다.
     func startPublishingWhiteboard()
 }

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -7,11 +7,11 @@
 
 public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     private let repository: WhiteboardRepositoryInterface
-    private var participantsInfo: [String: String] = [:]
+    private var participantsInfo: [String] = []
 
     public init(repository: WhiteboardRepositoryInterface, profile: Profile) {
         self.repository = repository
-        participantsInfo["participants"] = profile.profileIcon.emoji
+        participantsInfo.append(profile.profileIcon.emoji)
     }
 
     public func createWhiteboard(nickname: String) -> Whiteboard {

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -7,11 +7,11 @@
 
 public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     private let repository: WhiteboardRepositoryInterface
-    private var participantsInfo: [String] = []
+    private var participantsInfo: [Profile] = []
 
     public init(repository: WhiteboardRepositoryInterface, profile: Profile) {
         self.repository = repository
-        participantsInfo.append(profile.profileIcon.emoji)
+        participantsInfo.append(profile)
     }
 
     public func createWhiteboard(nickname: String) -> Whiteboard {

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -7,9 +7,11 @@
 
 public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     private let repository: WhiteboardRepositoryInterface
+    private var participantsInfo: [String: String] = [:]
 
-    public init(repository: WhiteboardRepositoryInterface) {
+    public init(repository: WhiteboardRepositoryInterface, profile: Profile) {
         self.repository = repository
+        participantsInfo["participants"] = profile.profileIcon.emoji
     }
 
     public func createWhiteboard(nickname: String) -> Whiteboard {
@@ -17,6 +19,6 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     }
 
     public func startPublishingWhiteboard() {
-        repository.startPublishing()
+        repository.startPublishing(with: participantsInfo)
     }
 }

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -14,7 +14,7 @@ public final class NearbyNetworkService: NSObject {
     public weak var delegate: NearbyNetworkDelegate?
     private let peerID: MCPeerID
     private let session: MCSession
-    private let serviceAdvertiser: MCNearbyServiceAdvertiser
+    private var serviceAdvertiser: MCNearbyServiceAdvertiser
     private let serviceBrowser: MCNearbyServiceBrowser
     private var connectedPeers: [MCPeerID: NetworkConnection] = [:]
     private var foundPeers: [MCPeerID: NetworkConnection] = [:] {
@@ -54,6 +54,18 @@ extension NearbyNetworkService: NearbyNetworkInterface {
 
     public func startPublishing() {
         serviceAdvertiser.startAdvertisingPeer()
+    }
+
+    public func startPublishing(with info: [String: String]) {
+        Task {
+            serviceAdvertiser.stopAdvertisingPeer()
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            serviceAdvertiser =  MCNearbyServiceAdvertiser(
+                peer: peerID,
+                discoveryInfo: info,
+                serviceType: serviceAdvertiser.serviceType)
+            serviceAdvertiser.startAdvertisingPeer()
+        }
     }
 
     public func stopPublishing() {

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -14,6 +14,7 @@ final class WhiteboardViewModel: ViewModel {
         case startDrawing(startAt: CGPoint)
         case addDrawingPoint(point: CGPoint)
         case finishUsingTool
+        case publishWithInfo
     }
 
     struct Output {
@@ -25,14 +26,16 @@ final class WhiteboardViewModel: ViewModel {
 
     let output: Output
     private let drawObjectUseCase: DrawObjectUseCaseInterface
+    private let whiteboardUseCase: WhiteboardUseCaseInterface
     private var whiteboardObjects: [WhiteboardObject]
     private let currentTool: CurrentValueSubject<WhiteboardTool?, Never>
     let addedWhiteboardObjectSubject: PassthroughSubject<WhiteboardObject, Never>
     let updatedWhiteboardObjectSubject: PassthroughSubject<WhiteboardObject, Never>
     let removedWhiteboardObjectSubject: PassthroughSubject<WhiteboardObject, Never>
 
-    init(drawObjectUseCase: DrawObjectUseCaseInterface) {
+    init(drawObjectUseCase: DrawObjectUseCaseInterface, whiteboardUseCase: WhiteboardUseCaseInterface) {
         self.drawObjectUseCase = drawObjectUseCase
+        self.whiteboardUseCase = whiteboardUseCase
         whiteboardObjects = []
         currentTool = CurrentValueSubject<WhiteboardTool?, Never>(nil)
         addedWhiteboardObjectSubject = PassthroughSubject<WhiteboardObject, Never>()
@@ -56,6 +59,8 @@ final class WhiteboardViewModel: ViewModel {
             addDrawingPoint(at: point)
         case .finishUsingTool:
             finishUsingTool()
+        case .publishWithInfo:
+            startPublishing()
         }
     }
 
@@ -99,5 +104,9 @@ final class WhiteboardViewModel: ViewModel {
         guard let drawingObject = drawObjectUseCase.finishDrawing() else { return }
         addedWhiteboardObjectSubject.send(drawingObject)
         addWhiteboardObject(object: drawingObject)
+    }
+
+    private func startPublishing() {
+        whiteboardUseCase.startPublishingWhiteboard()
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -14,7 +14,6 @@ final class WhiteboardViewModel: ViewModel {
         case startDrawing(startAt: CGPoint)
         case addDrawingPoint(point: CGPoint)
         case finishUsingTool
-        case publishWithInfo
     }
 
     struct Output {
@@ -59,8 +58,6 @@ final class WhiteboardViewModel: ViewModel {
             addDrawingPoint(at: point)
         case .finishUsingTool:
             finishUsingTool()
-        case .publishWithInfo:
-            startPublishing()
         }
     }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
유저가 메인 화면에서 browsing 시작하면 각 화이트보드 cell에 참여자 수와 아이콘을 표시하기 위한 PR입니다. 

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
로직이라 작동 영상은 없습니다


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
`NearbyNetworkService` 내부 `startPublishing` 메서드 오버로딩해서 `discoveryInfo`에 참여자 정보 전달
수정된 `NearbyNetworkService`에 맞게 repository, usecase, viewmodel 수정

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
`discoveryInfo`를 통해 advertising 상황에서 상호 정보 교환 상황은 슬랙에 있는 .zip 파일로 테스트 했습니다. [파일](https://boostcampwm9-me.slack.com/files/U07H9CUR2LU/F0817GLG4LD/airplain_poc_2.zip)


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- advertising 실패 시 에러 처리
- 현재 advertising stop 후 바로 start하면 예상하는 대로 동작하지 않는 이슈가 있어 3초의 시간 텀을 강제로 주고있습니다. 추후에 개선이 필요해보입니다. 