### PR TITLE
[Feature] 텍스트 오브젝트 추가 구현

### DIFF
--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		5BDFD93A2CE2EE3100DA4F5B /* WhiteboardUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDFD9392CE2EE3100DA4F5B /* WhiteboardUseCase.swift */; };
 		6F21477B2CE4CEAE00B55E2C /* TextObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21477A2CE4CEAE00B55E2C /* TextObject.swift */; };
 		6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */; };
+		6F68E7852CEC200000945394 /* TextObjectUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7842CEC200000945394 /* TextObjectUseCase.swift */; };
 		6FBC909B2CE5A6AE000FEB5A /* WhiteObjectSendUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */; };
 		A85260232CE343B20089DA5E /* ProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85260222CE343B20089DA5E /* ProfileUseCase.swift */; };
 		A8E97BD82CE5A6B800B28063 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E97BD62CE5A6B800B28063 /* Profile.swift */; };
@@ -85,6 +86,7 @@
 		5BDFD9392CE2EE3100DA4F5B /* WhiteboardUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardUseCase.swift; sourceTree = "<group>"; };
 		6F21477A2CE4CEAE00B55E2C /* TextObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObject.swift; sourceTree = "<group>"; };
 		6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseInterface.swift; sourceTree = "<group>"; };
+		6F68E7842CEC200000945394 /* TextObjectUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCase.swift; sourceTree = "<group>"; };
 		6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteObjectSendUseCaseInterface.swift; sourceTree = "<group>"; };
 		A85260222CE343B20089DA5E /* ProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUseCase.swift; sourceTree = "<group>"; };
 		A8E97BD62CE5A6B800B28063 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 		00683D702CE3A72F000D28E4 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				6F68E7842CEC200000945394 /* TextObjectUseCase.swift */,
 				00683D712CE3A74A000D28E4 /* DrawObjectUseCase.swift */,
 				A8E97C062CE5E45500B28063 /* WhiteboardObjectSendUseCase.swift */,
 				A85260222CE343B20089DA5E /* ProfileUseCase.swift */,
@@ -401,6 +404,7 @@
 				00D2DD882CE88BD80089F0BA /* ManageWhiteboardToolUseCaseInterface.swift in Sources */,
 				0080E8CE2CE4463B0095B958 /* WhiteboardObjectRepositoryInterface.swift in Sources */,
 				0080E8BB2CE2ECD80095B958 /* WhiteboardObject.swift in Sources */,
+				6F68E7852CEC200000945394 /* TextObjectUseCase.swift in Sources */,
 				6FBC909B2CE5A6AE000FEB5A /* WhiteObjectSendUseCaseInterface.swift in Sources */,
 				6F21477B2CE4CEAE00B55E2C /* TextObject.swift in Sources */,
 				00683D722CE3A74A000D28E4 /* DrawObjectUseCase.swift in Sources */,

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		5BDFD9372CE2E6BC00DA4F5B /* WhiteboardRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDFD9362CE2E6BC00DA4F5B /* WhiteboardRepositoryInterface.swift */; };
 		5BDFD93A2CE2EE3100DA4F5B /* WhiteboardUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDFD9392CE2EE3100DA4F5B /* WhiteboardUseCase.swift */; };
 		6F21477B2CE4CEAE00B55E2C /* TextObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21477A2CE4CEAE00B55E2C /* TextObject.swift */; };
+		6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */; };
 		6FBC909B2CE5A6AE000FEB5A /* WhiteObjectSendUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */; };
 		A85260232CE343B20089DA5E /* ProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85260222CE343B20089DA5E /* ProfileUseCase.swift */; };
 		A8E97BD82CE5A6B800B28063 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E97BD62CE5A6B800B28063 /* Profile.swift */; };
@@ -83,6 +84,7 @@
 		5BDFD9362CE2E6BC00DA4F5B /* WhiteboardRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardRepositoryInterface.swift; sourceTree = "<group>"; };
 		5BDFD9392CE2EE3100DA4F5B /* WhiteboardUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardUseCase.swift; sourceTree = "<group>"; };
 		6F21477A2CE4CEAE00B55E2C /* TextObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObject.swift; sourceTree = "<group>"; };
+		6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseInterface.swift; sourceTree = "<group>"; };
 		6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteObjectSendUseCaseInterface.swift; sourceTree = "<group>"; };
 		A85260222CE343B20089DA5E /* ProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUseCase.swift; sourceTree = "<group>"; };
 		A8E97BD62CE5A6B800B28063 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 		0080E9192CE4B0880095B958 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */,
 				0080E9182CE4B0880095B958 /* DrawObjectUseCaseInterface.swift */,
 				A8E97C042CE5E3AB00B28063 /* ProfileUseCaseInterface.swift */,
 				6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */,
@@ -394,6 +397,7 @@
 				5BDFD9372CE2E6BC00DA4F5B /* WhiteboardRepositoryInterface.swift in Sources */,
 				5B6542482CE44631000168AD /* WhiteboardUseCaseInterface.swift in Sources */,
 				00D2DD842CE8864B0089F0BA /* ManageWhiteboardObjectUseCaseInterface.swift in Sources */,
+				6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */,
 				00D2DD882CE88BD80089F0BA /* ManageWhiteboardToolUseCaseInterface.swift in Sources */,
 				0080E8CE2CE4463B0095B958 /* WhiteboardObjectRepositoryInterface.swift in Sources */,
 				0080E8BB2CE2ECD80095B958 /* WhiteboardObject.swift in Sources */,

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		6F21477B2CE4CEAE00B55E2C /* TextObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21477A2CE4CEAE00B55E2C /* TextObject.swift */; };
 		6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */; };
 		6F68E7852CEC200000945394 /* TextObjectUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7842CEC200000945394 /* TextObjectUseCase.swift */; };
+		6F68E7872CEC593300945394 /* TextObjectUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */; };
 		6FBC909B2CE5A6AE000FEB5A /* WhiteObjectSendUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */; };
 		A85260232CE343B20089DA5E /* ProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85260222CE343B20089DA5E /* ProfileUseCase.swift */; };
 		A8E97BD82CE5A6B800B28063 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E97BD62CE5A6B800B28063 /* Profile.swift */; };
@@ -87,6 +88,7 @@
 		6F21477A2CE4CEAE00B55E2C /* TextObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObject.swift; sourceTree = "<group>"; };
 		6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseInterface.swift; sourceTree = "<group>"; };
 		6F68E7842CEC200000945394 /* TextObjectUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCase.swift; sourceTree = "<group>"; };
+		6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseTests.swift; sourceTree = "<group>"; };
 		6FBC909A2CE5A52B000FEB5A /* WhiteObjectSendUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteObjectSendUseCaseInterface.swift; sourceTree = "<group>"; };
 		A85260222CE343B20089DA5E /* ProfileUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileUseCase.swift; sourceTree = "<group>"; };
 		A8E97BD62CE5A6B800B28063 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				0080E9562CE4D8760095B958 /* DrawObjectUseCaseTests.swift */,
 				00D2DD922CE88EC70089F0BA /* ManageWhiteboardToolUseCaseTests.swift */,
 				00D2DD942CE88EDA0089F0BA /* ManageWhiteboardObjectsUseCaseTests.swift */,
+				6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */,
 			);
 			path = DomainTests;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 				00D2DD952CE88EDA0089F0BA /* ManageWhiteboardObjectsUseCaseTests.swift in Sources */,
 				0080E9582CE4D8760095B958 /* DrawObjectUseCaseTests.swift in Sources */,
 				00D2DD932CE88EC70089F0BA /* ManageWhiteboardToolUseCaseTests.swift in Sources */,
+				6F68E7872CEC593300945394 /* TextObjectUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
@@ -1,0 +1,19 @@
+//
+//  TextObjectUseCaseInterface.swift
+//  Domain
+//
+//  Created by 박승찬 on 11/18/24.
+//
+
+import Combine
+import Foundation
+
+public protocol TextObjectUseCaseInterface {
+    /// TextObject를 생성하고 반환합니다.
+    /// 현재 화면 중앙에 위치할 수 있도록 조절합니다.
+    /// - Parameters:
+    ///   - scrollViewOffset: 현재 스크롤뷰가 보고있는 위치
+    ///   - viewSize: 현재 뷰의 크기
+    /// - Returns: 현재 화면 중앙에 위치한 TextObject를 반환
+    func addText(scrollViewOffset: CGPoint, viewSize: CGSize) -> TextObject
+}

--- a/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
@@ -15,5 +15,5 @@ public protocol TextObjectUseCaseInterface {
     ///   - scrollViewOffset: 현재 스크롤뷰가 보고있는 위치
     ///   - viewSize: 현재 뷰의 크기
     /// - Returns: 현재 화면 중앙에 위치한 TextObject를 반환
-    func addText(scrollViewOffset: CGPoint, viewSize: CGSize) -> TextObject
+    func addText(point: CGPoint, size: CGSize) -> TextObject
 }

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  TextObjectUseCase.swift
+//  Domain
+//
+//  Created by 박승찬 on 11/19/24.
+//
+
+import Combine
+import Foundation
+
+public final class TextObjectUseCase: TextObjectUseCaseInterface {
+    private let textFieldDefaultSize: CGSize
+
+    public init(textFieldDefaultSize: CGSize) {
+        self.textFieldDefaultSize = textFieldDefaultSize
+    }
+
+    public func addText(scrollViewOffset: CGPoint, viewSize: CGSize) -> TextObject {
+        let positionX = scrollViewOffset.x + viewSize.width / 3
+        let positionY = scrollViewOffset.y + viewSize.height / 3
+        let position = CGPoint(x: positionX, y: positionY)
+        return TextObject(
+            id: UUID(),
+            position: position,
+            size: textFieldDefaultSize,
+            text: "")
+    }
+}

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -15,9 +15,9 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
         self.textFieldDefaultSize = textFieldDefaultSize
     }
 
-    public func addText(scrollViewOffset: CGPoint, viewSize: CGSize) -> TextObject {
-        let positionX = scrollViewOffset.x + viewSize.width / 3
-        let positionY = scrollViewOffset.y + viewSize.height / 3
+    public func addText(point: CGPoint, size: CGSize) -> TextObject {
+        let positionX = point.x + size.width / 3
+        let positionY = point.y + size.height / 3
         let position = CGPoint(x: positionX, y: positionY)
         return TextObject(
             id: UUID(),

--- a/Domain/DomainTests/TextObjectUseCaseTests.swift
+++ b/Domain/DomainTests/TextObjectUseCaseTests.swift
@@ -1,0 +1,74 @@
+//
+//  TextObjectUseCaseTests.swift
+//  DomainTests
+//
+//  Created by 박승찬 on 11/19/24.
+//
+
+import Domain
+import XCTest
+
+final class TextObjectUseCaseTests: XCTestCase {
+    private var useCase: TextObjectUseCase!
+
+    override func setUpWithError() throws {
+        let mockCGSize = CGSize(width: 200, height: 50)
+        useCase = TextObjectUseCase(textFieldDefaultSize: mockCGSize)
+    }
+
+    override func tearDownWithError() throws {
+        useCase = nil
+    }
+
+    // addText테스트
+    // 정상적인 입력
+    func testIdealAddText() {
+        // 준비
+        let testScrollViewOffset = CGPoint(x: 0, y: 0)
+        let testViewSize = CGSize(width: 300, height: 300)
+        let expectedPosition = CGPoint(
+            x: testScrollViewOffset.x + testViewSize.width / 3,
+            y: testScrollViewOffset.y + testViewSize.height / 3)
+
+        // 실행
+        let createdTextObject = useCase.addText(scrollViewOffset: testScrollViewOffset, viewSize: testViewSize)
+
+        // 검증
+        XCTAssertEqual(createdTextObject.position, expectedPosition)
+    }
+
+    // addText테스트
+    // 비정상적인 입력(0)
+    func testStrangeZeroAddText() {
+        // 준비
+        let testScrollViewOffset = CGPoint(x: 0, y: 0)
+        let testViewSize = CGSize(width: 0, height: 0)
+        let expectedPosition = CGPoint(
+            x: testScrollViewOffset.x + testViewSize.width / 3,
+            y: testScrollViewOffset.y + testViewSize.height / 3)
+
+        // 실행
+        let createdTextObject = useCase.addText(scrollViewOffset: testScrollViewOffset, viewSize: testViewSize)
+
+        // 검증
+        XCTAssertEqual(createdTextObject.position, expectedPosition)
+    }
+
+    // addText테스트
+    // 비정상적인 입력(마이너스)
+    func testStrangeMinusAddText() {
+        // 준비
+        let testScrollViewOffset = CGPoint(x: 0, y: 0)
+        let testViewSize = CGSize(width: -300, height: -300)
+        let expectedPosition = CGPoint(
+            x: testScrollViewOffset.x + testViewSize.width / 3,
+            y: testScrollViewOffset.y + testViewSize.height / 3)
+
+        // 실행
+        let createdTextObject = useCase.addText(scrollViewOffset: testScrollViewOffset, viewSize: testViewSize)
+
+        // 검증
+        XCTAssertEqual(createdTextObject.position, expectedPosition)
+    }
+
+}

--- a/Domain/DomainTests/TextObjectUseCaseTests.swift
+++ b/Domain/DomainTests/TextObjectUseCaseTests.swift
@@ -31,7 +31,7 @@ final class TextObjectUseCaseTests: XCTestCase {
             y: testScrollViewOffset.y + testViewSize.height / 3)
 
         // 실행
-        let createdTextObject = useCase.addText(scrollViewOffset: testScrollViewOffset, viewSize: testViewSize)
+        let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
 
         // 검증
         XCTAssertEqual(createdTextObject.position, expectedPosition)
@@ -48,7 +48,7 @@ final class TextObjectUseCaseTests: XCTestCase {
             y: testScrollViewOffset.y + testViewSize.height / 3)
 
         // 실행
-        let createdTextObject = useCase.addText(scrollViewOffset: testScrollViewOffset, viewSize: testViewSize)
+        let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
 
         // 검증
         XCTAssertEqual(createdTextObject.position, expectedPosition)
@@ -65,7 +65,7 @@ final class TextObjectUseCaseTests: XCTestCase {
             y: testScrollViewOffset.y + testViewSize.height / 3)
 
         // 실행
-        let createdTextObject = useCase.addText(scrollViewOffset: testScrollViewOffset, viewSize: testViewSize)
+        let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
 
         // 검증
         XCTAssertEqual(createdTextObject.position, expectedPosition)

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -9,13 +9,14 @@ import Domain
 import UIKit
 
 final class TextObjectView: WhiteboardObjectView {
-    let textField: UITextField = {
+    private lazy var textField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "Hello AirplaIN"
+        textField.delegate = self
         return textField
     }()
 
-    let textObject: TextObject
+    private let textObject: TextObject
 
     init(textObject: TextObject) {
         self.textObject = textObject
@@ -33,9 +34,30 @@ final class TextObjectView: WhiteboardObjectView {
         super.init(coder: coder)
     }
 
+    override func becomeFirstResponder() -> Bool {
+        textField.becomeFirstResponder()
+    }
+
     private func configureLayout() {
         textField
             .addToSuperview(self)
             .edges(equalTo: self)
+    }
+}
+
+extension TextObjectView: UITextFieldDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        let maxLength = 15
+        guard let text = textField.text else { return true }
+        let newlength = text.count + string.count - range.length
+        return newlength < maxLength
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -9,10 +9,9 @@ import Domain
 import UIKit
 
 final class TextObjectView: WhiteboardObjectView {
-    private lazy var textField: UITextField = {
+    private let textField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "Hello AirplaIN"
-        textField.delegate = self
         return textField
     }()
 
@@ -21,7 +20,7 @@ final class TextObjectView: WhiteboardObjectView {
     init(textObject: TextObject) {
         self.textObject = textObject
         super.init(whiteboardObject: textObject)
-
+        configureAttribute()
         configureLayout()
     }
 
@@ -36,6 +35,10 @@ final class TextObjectView: WhiteboardObjectView {
 
     override func becomeFirstResponder() -> Bool {
         textField.becomeFirstResponder()
+    }
+
+    private func configureAttribute() {
+        textField.delegate = self
     }
 
     private func configureLayout() {

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -91,6 +91,7 @@ public class WhiteboardViewController: UIViewController {
             .sink { [weak self] object in
                 guard let objectView = self?.objectViewFactory.create(with: object) else { return }
                 self?.addObjectView(objectView: objectView)
+                objectView.becomeFirstResponder()
             }
             .store(in: &cancellables)
 
@@ -121,6 +122,11 @@ public class WhiteboardViewController: UIViewController {
 
     private func addText() {
         viewModel.action(input: .addTextObject(scrollViewOffset: scrollView.contentOffset, viewSize: view.frame.size))
+    }
+
+    // TODO: 이후에 Done 버튼이 생길경우 사용할 메소드
+    private func endEditObject() {
+        view.endEditing(true)
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -118,12 +118,17 @@ public class WhiteboardViewController: UIViewController {
     private func addObjectView(objectView: WhiteboardObjectView) {
         canvasView.addSubview(objectView)
     }
+
+    private func addText() {
+        viewModel.action(input: .addTextObject(scrollViewOffset: scrollView.contentOffset, viewSize: view.frame.size))
+    }
 }
 
 // MARK: - WhiteboardToolBarDelegate
 extension WhiteboardViewController: WhiteboardToolBarDelegate {
     func whiteboardToolBar(_ sender: WhiteboardToolBar, selectedTool: WhiteboardTool) {
         viewModel.action(input: .selectTool(tool: selectedTool))
+        if selectedTool == .text { addText() }
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -8,7 +8,7 @@ import Combine
 import Domain
 import Foundation
 
-public final class WhiteboardViewModel: ViewModel {
+final class WhiteboardViewModel: ViewModel {
     enum Input {
         case selectTool(tool: WhiteboardTool)
         case startDrawing(startAt: CGPoint)
@@ -116,7 +116,7 @@ public final class WhiteboardViewModel: ViewModel {
     }
 
     private func addText(scrollViewOffset: CGPoint, viewSize: CGSize) {
-        let textObject = textObjectUseCase.addText(scrollViewOffset: scrollViewOffset, viewSize: viewSize)
+        let textObject = textObjectUseCase.addText(point: scrollViewOffset, size: viewSize)
         addWhiteboardObject(object: textObject)
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -8,13 +8,14 @@ import Combine
 import Domain
 import Foundation
 
-final class WhiteboardViewModel: ViewModel {
+public final class WhiteboardViewModel: ViewModel {
     enum Input {
         case selectTool(tool: WhiteboardTool)
         case startDrawing(startAt: CGPoint)
         case addDrawingPoint(point: CGPoint)
         case finishDrawing
         case finishUsingTool
+        case addTextObject(scrollViewOffset: CGPoint, viewSize: CGSize)
     }
 
     struct Output {
@@ -26,15 +27,18 @@ final class WhiteboardViewModel: ViewModel {
 
     let output: Output
     private let drawObjectUseCase: DrawObjectUseCaseInterface
+    private let textObjectUseCase: TextObjectUseCaseInterface
     private let manageWhiteboardToolUseCase: ManageWhiteboardToolUseCaseInterface
     private let manageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseInterface
 
-    init(
+    public init(
         drawObjectUseCase: DrawObjectUseCaseInterface,
+        textObjectUseCase: TextObjectUseCaseInterface,
         managemanageWhiteboardToolUseCase: ManageWhiteboardToolUseCaseInterface,
         manageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseInterface
     ) {
         self.drawObjectUseCase = drawObjectUseCase
+        self.textObjectUseCase = textObjectUseCase
         self.manageWhiteboardToolUseCase = managemanageWhiteboardToolUseCase
         self.manageWhiteboardObjectUseCase = manageWhiteboardObjectUseCase
 
@@ -65,6 +69,8 @@ final class WhiteboardViewModel: ViewModel {
             finishDrawing()
         case .finishUsingTool:
             finishUsingTool()
+        case .addTextObject(scrollViewOffset: let scrollViewOffset, viewSize: let viewSize):
+            addText(scrollViewOffset: scrollViewOffset, viewSize: viewSize)
         }
     }
 
@@ -107,5 +113,10 @@ final class WhiteboardViewModel: ViewModel {
     private func finishDrawing() {
         guard let drawingObject = drawObjectUseCase.finishDrawing() else { return }
         addWhiteboardObject(object: drawingObject)
+    }
+
+    private func addText(scrollViewOffset: CGPoint, viewSize: CGSize) {
+        let textObject = textObjectUseCase.addText(scrollViewOffset: scrollViewOffset, viewSize: viewSize)
+        addWhiteboardObject(object: textObject)
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
텍스트 오브젝트를  추가하는 로직과 뷰를 구현했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| iPhone SE3 | iPhone 13 mini | iPhone 16 Pro |
|--------|--------|--------|
|![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-11-19 at 13 19 03](https://github.com/user-attachments/assets/0863c523-6715-44b2-a22a-6e29f0772111)|![Simulator Screen Recording - iPhone 13 mini - 2024-11-19 at 13 22 59](https://github.com/user-attachments/assets/52c60289-732e-40b3-9d24-da1c7e70dbb7)|![Simulator Screen Recording - iPhone 16 Pro - 2024-11-19 at 13 24 56](https://github.com/user-attachments/assets/d3e54c66-a463-4420-8826-336b702b6e55)|


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 텍스트 오브젝트를 생성하는 로직을 구현했습니다
- 텍스트 오브젝트를 생성하기 위해 현재 화면이 보고있는 offset값을 가져와 처리하도록 해 주었습니다.

### 텍스트 오브젝트 추가 플로우
- 텍스트 오브젝트는 우선, 추가하여 빈 텍스트오브젝트를 추가하고, 전송 해 줍니다.
- 이후 수정 에픽 단계에서 오브젝트의 내용이 변할 경우 전송해주는 로직을 구현 할 계획입니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 목적과 상황
텍스트 오브젝트가 정상적인 위치에 생성되는지 유즈케이스를 테스트

- 시나리오 진행에 필요한 값
1. 화면의 크기
2. 지금 보고있는 스크롤뷰의 오프셋값

- 시나리오 진행에 필요한 조건
usecase 생성시 텍스트 오브젝트의 기본 크기를 설정하는 값을 넣어주어야 한다.

- 시나리오 완료 시 보장하는 결과
지금 보고있는 화면의 중상위 부근에 텍스트오브젝트가 생성되어야 한다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
### TextFieldDelegate를 이용하는 코드를 어디에 넣어야할지 고민입니다.
TextObjectView 내부에 TextField를 갖고있는데요, 만약 뷰컨트롤러에서 delegate를 주입해준다면, 생성시에 다른 WhiteboardObjectView와는 다르게 팩토리에서 delgate를 받아서 뱉어주거나, 따로 주입시켜주기위해 TextObjectView로 형변환을 해서 주입해주어야합니다...

그래서 우선은 TextObjectView자체에서 delegate채택후 주입시켜 주고 있습니다.

다만, 이렇게 될경우에는 delegate 메소드 내부에 들어가는 코드를 어떻게 처리해야할지 고민입니다..

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #7 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
