### PR TITLE
[Fix] 화이트보드 리스트 뷰 레이아웃 수정

### DIFF
--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -15,11 +15,12 @@ public final class WhiteboardListViewController: UIViewController {
         static let upperComponentTopMargin: CGFloat = 70
         static let mainTitleLabelWidth: CGFloat = 199
         static let mainTitleLabelHeight: CGFloat = 43
-        static let groupHeight: CGFloat = 130
+        static let itemHeight: CGFloat = 65
         static let itemVerticalMargin: CGFloat = 8
         static let labelLineSpacing: CGFloat = 10
         static let createButtonTrailingMargin: CGFloat = 29
         static let collectionViewTopMargin: CGFloat = 10
+        static let itemSpacing: CGFloat = 5
     }
 
     private let mainTitleLabel: UILabel = {
@@ -145,7 +146,7 @@ public final class WhiteboardListViewController: UIViewController {
     private func createCollectionViewLayout() -> UICollectionViewLayout {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(0.5))
+            heightDimension: .absolute(WhiteboardListLayoutConstant.itemHeight))
 
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
@@ -157,9 +158,10 @@ public final class WhiteboardListViewController: UIViewController {
 
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(WhiteboardListLayoutConstant.groupHeight))
+            heightDimension: .fractionalHeight(1.0))
 
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(WhiteboardListLayoutConstant.itemSpacing)
 
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
[이전 PR](https://github.com/boostcampwm-2024/iOS02-AirplaIN/pull/94)의 코드리뷰를 반영하는 layout이 예상과 다르게 적용되어 급하게 수정PR 올립니다. 
죄송합니다 ㅠㅠ

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| 수정 전 | 수정 후 | 
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-20 at 15 27 43](https://github.com/user-attachments/assets/8336821d-e373-4602-9c58-86e1af9e75e0) | ![Simulator Screenshot - iPhone 16 - 2024-11-20 at 15 27 44](https://github.com/user-attachments/assets/10ee2105-8f5e-41ce-b549-696d6f2061a2) |

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- CollectionView 레이아웃 수정