### PR TITLE
[Feature] 근거리 통신 모듈에 URL을 이용한 통신 메서드 추가

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -33,6 +33,12 @@ public protocol NearbyNetworkInterface {
     /// 연결된 기기들에게 데이터를 송신합니다.
     /// - Parameter data: 송신할 데이터
     func send(data: Data)
+
+    /// 연결된 기기들에게 파일을 송신합니다.
+    /// - Parameters:
+    ///   - fileURL: 파일의 URL
+    ///   - info: 파일에 대한 정보
+    func send(fileURL: URL, info: DataInformationDTO)
 }
 
 public protocol NearbyNetworkDelegate: AnyObject {
@@ -41,6 +47,18 @@ public protocol NearbyNetworkDelegate: AnyObject {
     ///   - data: 수신된 데이터
     ///   - connection: 데이터를 송신한 기기
     func nearbyNetwork(_ sender: NearbyNetworkInterface, didReceive data: Data, from connection: NetworkConnection)
+
+
+    /// 파일을 수신했을 때 실행됩니다.
+    /// - Parameters:
+    ///   - URL: 수신한 파일의 URL
+    ///   - Connection: 데이터를 송신한 기기
+    ///   - info: 파일에 대한 정보
+    func nearbyNetwork(
+        _ sender: NearbyNetworkInterface,
+        didReceive URL: URL,
+        from Connection: NetworkConnection,
+        info: DataInformationDTO)
 
     /// 주변 기기에게 연결 요청을 받았을 때 실행됩니다.
     /// - Parameters:

--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol NearbyNetworkInterface {
-    var delegate: NearbyNetworkDelegate? { get set }
+    var connectionDelegate: NearbyNetworkConnectionDelegate? { get set }
 
     /// 주변 기기를 검색합니다.
     func startSearching()
@@ -38,28 +38,10 @@ public protocol NearbyNetworkInterface {
     /// - Parameters:
     ///   - fileURL: 파일의 URL
     ///   - info: 파일에 대한 정보
-    func send(fileURL: URL, info: DataInformationDTO)
+    func send(fileURL: URL, info: DataInformationDTO) async
 }
 
-public protocol NearbyNetworkDelegate: AnyObject {
-    /// 데이터를 수신했을 때 실행됩니다.
-    /// - Parameters:
-    ///   - data: 수신된 데이터
-    ///   - connection: 데이터를 송신한 기기
-    func nearbyNetwork(_ sender: NearbyNetworkInterface, didReceive data: Data, from connection: NetworkConnection)
-
-
-    /// 파일을 수신했을 때 실행됩니다.
-    /// - Parameters:
-    ///   - URL: 수신한 파일의 URL
-    ///   - Connection: 데이터를 송신한 기기
-    ///   - info: 파일에 대한 정보
-    func nearbyNetwork(
-        _ sender: NearbyNetworkInterface,
-        didReceive URL: URL,
-        from Connection: NetworkConnection,
-        info: DataInformationDTO)
-
+public protocol NearbyNetworkConnectionDelegate: AnyObject {
     /// 주변 기기에게 연결 요청을 받았을 때 실행됩니다.
     /// - Parameters:
     ///   - connectionHandler: 연결 요청 처리 Handler
@@ -72,4 +54,20 @@ public protocol NearbyNetworkDelegate: AnyObject {
 
     /// 주변 기기와의 연결에 실패했을 때 실행됩니다.
     func nearbyNetworkCannotConnect(_ sender: NearbyNetworkInterface)
+}
+
+public protocol NearbyNetworkReceiptDelegate: AnyObject {
+    /// 데이터를 수신했을 때 실행됩니다.
+    /// - Parameters:
+    ///   - data: 수신된 데이터
+    func nearbyNetwork(_ sender: NearbyNetworkInterface, didReceive data: Data)
+
+    /// 파일을 수신했을 때 실행됩니다.
+    /// - Parameters:
+    ///   - URL: 수신한 파일의 URL
+    ///   - info: 파일에 대한 정보
+    func nearbyNetwork(
+        _ sender: NearbyNetworkInterface,
+        didReceiveURL URL: URL,
+        info: DataInformationDTO)
 }

--- a/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
+++ b/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public struct DataInformationDTO: Codable {
-    public let identifier: UUID
+    public let id: UUID
     public let type: AirplaINDataType
 }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -12,9 +12,9 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
     private var nearbyNetwork: NearbyNetworkInterface
     public weak var delegate: WhiteboardRepositoryDelegate?
 
-    public init(nearbyNetworkInterface: NearbyNetworkInterface) {
+    public init(nearbyNetworkInterface: NearbyNetworkInterface & NearbyNetworkConnectionDelegate) {
         self.nearbyNetwork = nearbyNetworkInterface
-        self.nearbyNetwork.delegate = self
+        self.nearbyNetwork.connectionDelegate = self
     }
 
     public func startPublishing(with info: [Profile]) {
@@ -33,14 +33,7 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
     }
 }
 
-extension WhiteboardRepository: NearbyNetworkDelegate {
-    public func nearbyNetwork(
-        _ sender: any NearbyNetworkInterface,
-        didReceive data: Data,
-        from connection: NetworkConnection) {
-        // TODO: -
-    }
-
+extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
     public func nearbyNetwork(
         _ sender: any NearbyNetworkInterface,
         didReceive connectionHandler: @escaping (

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -12,7 +12,7 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
     private var nearbyNetwork: NearbyNetworkInterface
     public weak var delegate: WhiteboardRepositoryDelegate?
 
-    public init(nearbyNetworkInterface: NearbyNetworkInterface & NearbyNetworkConnectionDelegate) {
+    public init(nearbyNetworkInterface: NearbyNetworkInterface) {
         self.nearbyNetwork = nearbyNetworkInterface
         self.nearbyNetwork.connectionDelegate = self
     }

--- a/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
+++ b/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00549AD62CEDDDB700DF8F6C /* MCSessionState+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */; };
+		00549AD82CEDDDCF00DF8F6C /* MCSession+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */; };
 		0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */; };
 		5B7C6EBF2CDB6C6E0024704A /* DataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EBE2CDB6C6E0024704A /* DataSource.framework */; };
 		5B7C6EC02CDB6C6E0024704A /* DataSource.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EBE2CDB6C6E0024704A /* DataSource.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -27,6 +29,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSessionState+.swift"; sourceTree = "<group>"; };
+		00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSession+.swift"; sourceTree = "<group>"; };
 		0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkService.swift; sourceTree = "<group>"; };
 		5B7C6E652CDB6A560024704A /* NearbyNetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NearbyNetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B7C6EBE2CDB6C6E0024704A /* DataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -44,9 +48,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00549AD32CEDDDA300DF8F6C /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				00549AD42CEDDDA800DF8F6C /* Extension */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		00549AD42CEDDDA800DF8F6C /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */,
+				00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		0080E8682CE19EC40095B958 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				00549AD32CEDDDA300DF8F6C /* Common */,
 				0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */,
 			);
 			path = Sources;
@@ -190,6 +212,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				00549AD62CEDDDB700DF8F6C /* MCSessionState+.swift in Sources */,
+				00549AD82CEDDDCF00DF8F6C /* MCSession+.swift in Sources */,
 				0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NearbyNetwork/NearbyNetwork/Sources/Common/Extension/MCSession+.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/Common/Extension/MCSession+.swift
@@ -1,0 +1,33 @@
+//
+//  MCSession+.swift
+//  NearbyNetwork
+//
+//  Created by 이동현 on 11/20/24.
+//
+
+import MultipeerConnectivity
+
+// MARK: - Swift Concurrency로 wrapping
+extension MCSession {
+    func sendResource(
+        at resourceURL: URL,
+        withName resourceName: String,
+        toPeer peer: MCPeerID
+    ) async throws {
+        typealias Continuation = CheckedContinuation<Void, Error>
+
+        try await withCheckedThrowingContinuation { (continuation: Continuation) in
+            self.sendResource(
+                at: resourceURL,
+                withName: resourceName,
+                toPeer: peer
+            ) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}

--- a/NearbyNetwork/NearbyNetwork/Sources/Common/Extension/MCSession+.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/Common/Extension/MCSession+.swift
@@ -20,14 +20,13 @@ extension MCSession {
             self.sendResource(
                 at: resourceURL,
                 withName: resourceName,
-                toPeer: peer
-            ) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
+                toPeer: peer) { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
                 }
-            }
         }
     }
 }

--- a/NearbyNetwork/NearbyNetwork/Sources/Common/Extension/MCSessionState+.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/Common/Extension/MCSessionState+.swift
@@ -1,0 +1,23 @@
+//
+//  MCSessionState+.swift
+//  NearbyNetwork
+//
+//  Created by 이동현 on 11/20/24.
+//
+
+import MultipeerConnectivity
+
+extension MCSessionState {
+    var description: String {
+        switch self {
+        case .notConnected:
+            return "연결 끊김"
+        case .connecting:
+            return "연결 중"
+        case .connected:
+            return "연결 됨"
+        @unknown default:
+            return "알 수 없음"
+        }
+    }
+}

--- a/Persistence/Persistence/Souces/FilePersistence.swift
+++ b/Persistence/Persistence/Souces/FilePersistence.swift
@@ -29,7 +29,7 @@ public struct FilePersistence: FilePersistenceInterface {
         return write(
             to: directoryURL,
             with: data,
-            fileName: dataInfo.identifier.uuidString)
+            fileName: dataInfo.id.uuidString)
     }
 
     public func load(path: URL) -> Data? {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 단순 data만 receive 했을 때 어떤 entity로 디코딩 해야하는지 알 수 없는 문제가 발생했습니다.
- MCSession의 send 메서드에 local File의 URL과, 이름을 지정해서 보낼 수 있는 메서드가 있어 이걸 활용해 전송하기로 했습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 근거리 통신 모듈의 delegate가 너무 많은 역할을 수행하고 있다 느껴졌습니다. 해당 모듈을 사용하는 repository에서 사용하지 않는 인터페이스가 발생할 가능성이 있다고 판단하여 delegate 프로토콜을 두 개로 나누었습니다. [링크](DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift)
- @ekrud99 @choijungp  생참 팀에서 현재 사용하고 있는 WhiteboardObject에도 영향이 가는 작업이기 때문에 확인해주시면 감사하겠습니다. 적절한 delegate 명이 있다면 수정하도록 하겠습니다.
- 근거리 통신 모듈에 URL을 이용한 송신, 수신 메서드를 구현했습니다.

## ✅ Testing
- Framework의 동작이기 때문에 따로 테스트하지는 않았습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 에러 처리에 대한 정책이 필요하다고 생각합니다. 다만 아직은 구현이 더 급하기 때문에 조금 후순위로 미뤄도 괜찮을 것 같습니다.
- `MCSession`의 `sendResource` 메서드는 완료 핸들러를 통해 비동기 이벤트를 처리하는데요, 이를 Swift Concurrency로 래핑하였습니다.
- `sendResource`를 통해 데이터를 전송하는 방식은 일반 `send`와는 다르게 `peer`에게 1:1로 데이터를 송신합니다. 따라서 반복문으로 연결된 피어들에게 데이터를 전송해줘야 했습니다. 좀 더 효율적으로 전송하기 위해 `TaskGroup`을 이용하여 데이터를 병렬 전송하는 방법을 선택했습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #99 
- close #100


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
