### PR TITLE
[Refactor] Profile 주입 방법 개선

### DIFF
--- a/AirplaIN/AirplaIN/SceneDelegate.swift
+++ b/AirplaIN/AirplaIN/SceneDelegate.swift
@@ -23,14 +23,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         // TODO: - 임시 의존성 주입
+        let nearbyNetworkService = NearbyNetworkService(serviceName: "airplain")
+        let whiteboardRepository = WhiteboardRepository(nearbyNetworkInterface: nearbyNetworkService)
         let profileRepository = ProfileRepository(persistenceService: PersistenceService())
-        let profileUseCase = ProfileUseCase(repository: profileRepository)
-        let profile = profileRepository.loadProfile()
-
-        let nearbyNetworkService = NearbyNetworkService(profileName: profile.nickname, serviceName: "airplain")
-        let repository = WhiteboardRepository(nearbyNetworkInterface: nearbyNetworkService)
-        let whiteboardUseCase = WhiteboardUseCase(repository: repository, profile: profile)
-        let viewModel = WhiteboardListViewModel(whiteboardUseCase: whiteboardUseCase, nickname: profile.nickname)
+        let whiteboardUseCase = WhiteboardUseCase(
+            whiteboardRepository: whiteboardRepository,
+            profileRepository: profileRepository)
+        let viewModel = WhiteboardListViewModel(whiteboardUseCase: whiteboardUseCase)
         let viewController = WhiteboardListViewController(viewModel: viewModel)
 
         let window = UIWindow(windowScene: windowScene)

--- a/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
@@ -11,8 +11,7 @@ public protocol WhiteboardUseCaseInterface {
     var whiteboardListPublisher: AnyPublisher<[Whiteboard], Never> { get }
 
     /// 화이트보드를 생성합니다.
-    /// - Parameter nickname: 유저 닉네임(화이트보드의 이름으로 사용)
-    func createWhiteboard(nickname: String) -> Whiteboard
+    func createWhiteboard() -> Whiteboard
 
     /// 주변에 내 기기를 정보와 함께 알립니다.
     func startPublishingWhiteboard()

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -11,7 +11,6 @@ import Foundation
 public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     private var whiteboardRepository: WhiteboardRepositoryInterface
     private var profileRepository: ProfileRepositoryInterface
-    private let profile: Profile
     private let whiteboardListSubject: PassthroughSubject<[Whiteboard], Never>
     public let whiteboardListPublisher: AnyPublisher<[Whiteboard], Never>
 
@@ -21,13 +20,13 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     ) {
         self.whiteboardRepository = whiteboardRepository
         self.profileRepository = profileRepository
-        self.profile = profileRepository.loadProfile()
         whiteboardListSubject = PassthroughSubject<[Whiteboard], Never>()
         whiteboardListPublisher = whiteboardListSubject.eraseToAnyPublisher()
         self.whiteboardRepository.delegate = self
     }
 
     public func createWhiteboard() -> Whiteboard {
+        let profile = profileRepository.loadProfile()
         return Whiteboard(
             id: UUID(),
             name: profile.nickname,
@@ -35,6 +34,7 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     }
 
     public func startPublishingWhiteboard() {
+        let profile = profileRepository.loadProfile()
         whiteboardRepository.startPublishing(with: [profile])
     }
 

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -9,38 +9,41 @@ import Combine
 import Foundation
 
 public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
-    private var repository: WhiteboardRepositoryInterface
+    private var whiteboardRepository: WhiteboardRepositoryInterface
+    private var profileRepository: ProfileRepositoryInterface
     private let profile: Profile
-    private var participantsInfo: [Profile] = []
     private let whiteboardListSubject: PassthroughSubject<[Whiteboard], Never>
     public let whiteboardListPublisher: AnyPublisher<[Whiteboard], Never>
 
-    public init(repository: WhiteboardRepositoryInterface, profile: Profile) {
-        self.repository = repository
-        self.profile = profile
+    public init(
+        whiteboardRepository: WhiteboardRepositoryInterface,
+        profileRepository: ProfileRepositoryInterface
+    ) {
+        self.whiteboardRepository = whiteboardRepository
+        self.profileRepository = profileRepository
+        self.profile = profileRepository.loadProfile()
         whiteboardListSubject = PassthroughSubject<[Whiteboard], Never>()
         whiteboardListPublisher = whiteboardListSubject.eraseToAnyPublisher()
-        participantsInfo.append(profile)
-        self.repository.delegate = self
+        self.whiteboardRepository.delegate = self
     }
 
-    public func createWhiteboard(nickname: String) -> Whiteboard {
+    public func createWhiteboard() -> Whiteboard {
         return Whiteboard(
             id: UUID(),
-            name: nickname,
+            name: profile.nickname,
             participantIcons: [profile.profileIcon])
     }
 
     public func startPublishingWhiteboard() {
-        repository.startPublishing(with: participantsInfo)
+        whiteboardRepository.startPublishing(with: [profile])
     }
 
     public func startSearchingWhiteboard() {
-        repository.startSearching()
+        whiteboardRepository.startSearching()
     }
 
     public func stopSearchingWhiteboard() {
-        repository.stopSearching()
+        whiteboardRepository.stopSearching()
     }
 }
 

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -26,8 +26,9 @@ public final class NearbyNetworkService: NSObject {
     }
     private let logger = Logger()
 
-    public init(profileName: String, serviceName: String) {
-        peerID = MCPeerID(displayName: profileName)
+    public init(serviceName: String) {
+        // TODO: - displayName 
+        peerID = MCPeerID(displayName: "profileName")
         session = MCSession(peer: peerID)
         serviceAdvertiser =  MCNearbyServiceAdvertiser(
             peer: peerID,

--- a/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
@@ -11,7 +11,6 @@ import Foundation
 
 public final class WhiteboardListViewModel: ViewModel {
     private let whiteboardUseCase: WhiteboardUseCaseInterface
-    private var nickname: String
     private var cancellables = Set<AnyCancellable>()
 
     enum Input {
@@ -29,9 +28,8 @@ public final class WhiteboardListViewModel: ViewModel {
     private let whiteboardSubject: PassthroughSubject<Whiteboard, Never>
     private let whiteboardListSubject: CurrentValueSubject<[Whiteboard], Never>
 
-    public init(whiteboardUseCase: WhiteboardUseCaseInterface, nickname: String) {
+    public init(whiteboardUseCase: WhiteboardUseCaseInterface) {
         self.whiteboardUseCase = whiteboardUseCase
-        self.nickname = nickname
         whiteboardSubject = PassthroughSubject<Whiteboard, Never>()
         whiteboardListSubject = CurrentValueSubject<[Whiteboard], Never>([])
         self.output = Output(
@@ -51,7 +49,7 @@ public final class WhiteboardListViewModel: ViewModel {
     }
 
     private func createWhiteboard() {
-        let whiteboard = whiteboardUseCase.createWhiteboard(nickname: nickname)
+        let whiteboard = whiteboardUseCase.createWhiteboard()
         whiteboardUseCase.startPublishingWhiteboard()
         whiteboardSubject.send(whiteboard)
     }


### PR DESCRIPTION
## 🌁 Background
Persistence에 저장되어 있는 프로필을 꺼내오고 사용하는 로직을 일부 개선하였습니다.      


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

- 기존에는 `WhiteboardUseCase`, `WhiteboardListViewModel`, `NearbyNetworkService`에서 init시 nickname을 주입 받았습니다.
- 해당 방식을 `WhiteboardUseCase`가 ProfileRepository를 갖고 있고 해당 레파지토리 내부 구현되어 있는 메서드를 통해 Persistence에 저장된 프로필을 가져오도록 수정하였습니다.
- `NearbyNetworkService`에서 displayName에서 닉네임 표시하던 로직은 추후 info를 통해 닉네임을 주고 받도록 구현하기로 약속하였습니다. (TODO)