### PR TITLE
[Feature] WhiteListViewController와 ProfileViewController 연결

### DIFF
--- a/Presentation/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation/Presentation.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		A8525DCB2CE203D50089DA5E /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8525DCA2CE203D50089DA5E /* UIView+.swift */; };
 		A85260252CE3447E0089DA5E /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85260242CE3447E0089DA5E /* UIColor+.swift */; };
 		A85260292CE344C60089DA5E /* ProfileIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85260282CE344C60089DA5E /* ProfileIconView.swift */; };
+		A85AF8DF2CEF0FF50077262D /* Persistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A85AF8DE2CEF0FF50077262D /* Persistence.framework */; };
+		A85AF8E02CEF0FF50077262D /* Persistence.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A85AF8DE2CEF0FF50077262D /* Persistence.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A8E979C52CE493E900B28063 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E979C42CE493E900B28063 /* ProfileViewController.swift */; };
 		A8E979C72CE4945500B28063 /* LayoutConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E979C62CE4945500B28063 /* LayoutConstant.swift */; };
 		A8E979CA2CE49A1800B28063 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E979C92CE49A1800B28063 /* ProfileViewModel.swift */; };
@@ -42,6 +44,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				A85AF8E02CEF0FF50077262D /* Persistence.framework in Embed Frameworks */,
 				5B7C6EBB2CDB6C5C0024704A /* Domain.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -71,6 +74,7 @@
 		A8525DCA2CE203D50089DA5E /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		A85260242CE3447E0089DA5E /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		A85260282CE344C60089DA5E /* ProfileIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileIconView.swift; sourceTree = "<group>"; };
+		A85AF8DE2CEF0FF50077262D /* Persistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Persistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8E979C42CE493E900B28063 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		A8E979C62CE4945500B28063 /* LayoutConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConstant.swift; sourceTree = "<group>"; };
 		A8E979C92CE49A1800B28063 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
@@ -83,6 +87,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A85AF8DF2CEF0FF50077262D /* Persistence.framework in Frameworks */,
 				5B7C6EBA2CDB6C5C0024704A /* Domain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -213,6 +218,7 @@
 		5B7C6EB82CDB6C5C0024704A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A85AF8DE2CEF0FF50077262D /* Persistence.framework */,
 				5B7C6EB92CDB6C5C0024704A /* Domain.framework */,
 			);
 			name = Frameworks;

--- a/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
+++ b/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
@@ -215,6 +215,11 @@ final class ProfileViewController: UIViewController {
 
     @objc private func saveProfile() {
         viewModel.action(input: .saveProfile)
+        dismiss(animated: true)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
     }
 }
 

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -8,6 +8,9 @@
 import Combine
 import Domain
 import UIKit
+// TODO: - Profile View 이동 주입 시점 변경시 삭제 될 모듈 (DataSource, Persistence)
+import DataSource
+import Persistence
 
 public final class WhiteboardListViewController: UIViewController {
     private enum WhiteboardListLayoutConstant {
@@ -93,6 +96,17 @@ public final class WhiteboardListViewController: UIViewController {
             self?.viewModel.action(input: .createWhiteboard)
         }
         createWhiteboardButton.addAction(createWhiteboardAction, for: .touchUpInside)
+
+        // TODO: - Profile View 이동 주입 시점
+        let showProfileViewController = UIAction { [weak self] _ in
+            let profileRepository = ProfileRepository(persistenceService: PersistenceService())
+            let viewModel = ProfileViewModel(profileUseCase: ProfileUseCase(repository: profileRepository))
+            let profileViewController = UINavigationController(
+                rootViewController: ProfileViewController(viewModel: viewModel))
+            profileViewController.modalPresentationStyle = UIModalPresentationStyle.fullScreen
+            self?.present(profileViewController, animated: true)
+        }
+        configureProfileButton.addAction(showProfileViewController, for: .touchUpInside)
 
         configureCollectionView()
         configureDataSource()


### PR DESCRIPTION
## 🌁 Background
WhiteboardListViewController에서 프로필 버튼을 눌렀을 때 ProfileViewController로 이동하도록 하였습니다.     


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
| iPhone SE3 | iPhone 13 mini | iPhone 16 Pro |
|--------|--------|--------|
| <img width="200" src="https://github.com/user-attachments/assets/f6305e53-831c-4d4f-9e3e-c37b9dfbed86" /> | <img width="200" src="https://github.com/user-attachments/assets/4bc1af4e-3dcc-4b3d-8f83-e7e73e109c37" /> | <img width="200" src="https://github.com/user-attachments/assets/2d82835a-61ee-424d-b17d-0d53ca577c09" /> |


## 👩‍💻 Contents
- WhiteboardListViewController와 ProfileViewController 연결
- ProfileViewController에서 키보드 내리는 함수 override

## ✅ Testing
빌드 후 메인 화면에서 프로필 버튼 클릭하면 프로필 설정 화면으로 이동할 수 있습니다.   


## 📝 Review Note
- WhiteboardListViewController에서 ProfileViewController로 이동시 임시로 의존성을 다 생성해서 주입해주고 있습니다.
- 추후 수정해야 함 (모듈도 빼야 함)

