### PR TITLE
[Feature] WhiteboardObjectRepository 구현

### DIFF
--- a/DataSource/DataSource.xcodeproj/project.pbxproj
+++ b/DataSource/DataSource.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		5B7C6EB62CDB6C4B0024704A /* Domain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EB42CDB6C4B0024704A /* Domain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BDFD93D2CE2F56B00DA4F5B /* WhiteboardRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDFD93C2CE2F56B00DA4F5B /* WhiteboardRepository.swift */; };
 		6F4031422CEDDF0800948CCF /* FilePersistenceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4031412CEDDF0800948CCF /* FilePersistenceInterface.swift */; };
+		6FF51C792CEF07D2005DE9CD /* WhiteboardObjectRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF51C782CEF07D2005DE9CD /* WhiteboardObjectRepository.swift */; };
 		A8525F1E2CE326DB0089DA5E /* PersistenceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8525F1D2CE326DB0089DA5E /* PersistenceInterface.swift */; };
 		A852601E2CE339E70089DA5E /* ProfileRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A852601D2CE339E70089DA5E /* ProfileRepository.swift */; };
 /* End PBXBuildFile section */
@@ -42,6 +43,7 @@
 		5B7C6EB42CDB6C4B0024704A /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BDFD93C2CE2F56B00DA4F5B /* WhiteboardRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardRepository.swift; sourceTree = "<group>"; };
 		6F4031412CEDDF0800948CCF /* FilePersistenceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePersistenceInterface.swift; sourceTree = "<group>"; };
+		6FF51C782CEF07D2005DE9CD /* WhiteboardObjectRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectRepository.swift; sourceTree = "<group>"; };
 		A8525F1D2CE326DB0089DA5E /* PersistenceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceInterface.swift; sourceTree = "<group>"; };
 		A852601D2CE339E70089DA5E /* ProfileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRepository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -126,6 +128,7 @@
 			children = (
 				A852601D2CE339E70089DA5E /* ProfileRepository.swift */,
 				5BDFD93C2CE2F56B00DA4F5B /* WhiteboardRepository.swift */,
+				6FF51C782CEF07D2005DE9CD /* WhiteboardObjectRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -241,6 +244,7 @@
 				5BDFD93D2CE2F56B00DA4F5B /* WhiteboardRepository.swift in Sources */,
 				0080E8662CE19EC40095B958 /* NetworkConnection.swift in Sources */,
 				A852601E2CE339E70089DA5E /* ProfileRepository.swift in Sources */,
+				6FF51C792CEF07D2005DE9CD /* WhiteboardObjectRepository.swift in Sources */,
 				00549AD22CEDBB3E00DF8F6C /* DataInformationDTO.swift in Sources */,
 				6F4031422CEDDF0800948CCF /* FilePersistenceInterface.swift in Sources */,
 			);

--- a/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
@@ -13,6 +13,7 @@ public protocol FilePersistenceInterface {
     ///   - dataInfo: 저장할 데이터의 정보: uuid, 데이터타입
     ///   - data: 저장할 데이터
     /// - Returns: URL로 저장된 위치 반환
+    @discardableResult
     func save(dataInfo: DataInformationDTO, data: Data?) -> URL?
 
     /// path위치에 있는 데이터를 가져옵니다.

--- a/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
@@ -13,7 +13,7 @@ public protocol FilePersistenceInterface {
     ///   - dataInfo: 저장할 데이터의 정보: uuid, 데이터타입
     ///   - data: 저장할 데이터
     /// - Returns: URL로 저장된 위치 반환
-    func save(dataInfo: DataInformationDTO, data: Data) -> URL?
+    func save(dataInfo: DataInformationDTO, data: Data?) -> URL?
 
     /// path위치에 있는 데이터를 가져옵니다.
     /// - Parameter path: 가져올 데이터의 위치를 URL로 받습니다.

--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public protocol NearbyNetworkInterface {
     var connectionDelegate: NearbyNetworkConnectionDelegate? { get set }
+    var receiptDelegate: NearbyNetworkReceiptDelegate? { get set }
 
     /// 주변 기기를 검색합니다.
     func startSearching()

--- a/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
+++ b/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
@@ -10,5 +10,5 @@ import Foundation
 public struct DataInformationDTO: Codable {
     public let id: UUID
     public let type: AirplaINDataType
-    public let isDelete: Bool
+    public let isDeleted: Bool
 }

--- a/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
+++ b/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
@@ -10,4 +10,5 @@ import Foundation
 public struct DataInformationDTO: Codable {
     public let id: UUID
     public let type: AirplaINDataType
+    public let isDelete: Bool
 }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -1,0 +1,61 @@
+//
+//  WhiteboardObjectRepository.swift
+//  DataSource
+//
+//  Created by 박승찬 on 11/21/24.
+//
+
+import Domain
+import OSLog
+
+public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterface {
+    public weak var delegate: WhiteboardObjectRepositoryDelegate?
+    private var nearbyNetwork: NearbyNetworkInterface
+    private let filePersistence: FilePersistenceInterface
+    private let logger = Logger()
+
+    public init(nearbyNetwork: NearbyNetworkInterface, filePersistence: FilePersistenceInterface) {
+        self.nearbyNetwork = nearbyNetwork
+        self.filePersistence = filePersistence
+        self.nearbyNetwork.receiptDelegate = self
+    }
+
+    public func send(whiteboardObject: WhiteboardObject) async {
+        switch whiteboardObject {
+        case let textObject as TextObject:
+            await send(whiteboardObject: textObject, type: .text)
+        case let drawingObject as DrawingObject:
+            await send(whiteboardObject: drawingObject, type: .drawing)
+        case let photoObject as PhotoObject:
+            await send(whiteboardObject: photoObject, type: .photo)
+        default:
+            break
+        }
+    }
+
+    public func delete(whiteboardObject: WhiteboardObject) {
+//        <#code#>
+    }
+
+    private func send(whiteboardObject: WhiteboardObject, type: AirplaINDataType) async {
+        let objectData = try? JSONEncoder().encode(whiteboardObject)
+        let objectInformation = DataInformationDTO(id: whiteboardObject.id, type: type)
+        guard let url = filePersistence
+            .save(dataInfo: objectInformation, data: objectData)
+        else {
+            logger.log(level: .error, "url저장 실패: 데이터를 보내지 못했습니다.")
+            return
+        }
+        await nearbyNetwork.send(fileURL: url, info: objectInformation)
+    }
+}
+
+extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
+    public func nearbyNetwork(_ sender: any NearbyNetworkInterface, didReceive data: Data) {
+//        <#code#>
+    }
+    
+    public func nearbyNetwork(_ sender: any NearbyNetworkInterface, didReceiveURL URL: URL, info: DataInformationDTO) {
+//        <#code#>
+    }
+}

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -52,10 +52,34 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
 
 extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
     public func nearbyNetwork(_ sender: any NearbyNetworkInterface, didReceive data: Data) {
-//        <#code#>
+        // TODO: 사용하지 않을 인터페이스로 예상
     }
-    
+
     public func nearbyNetwork(_ sender: any NearbyNetworkInterface, didReceiveURL URL: URL, info: DataInformationDTO) {
-//        <#code#>
+        guard let receiveData = filePersistence.load(path: URL) else { return }
+        filePersistence.save(dataInfo: info, data: receiveData)
+        guard let whiteboardObject = try? JSONDecoder().decode(
+            info.type.decodableType,
+            from: receiveData)
+        else {
+            logger.log(level: .error, "WhiteboardObjectRepository: 전달받은 데이터 디코딩 실패")
+            return
+        }
+        delegate?.whiteboardObjectRepository(self, didReceive: whiteboardObject)
+    }
+}
+
+fileprivate extension AirplaINDataType {
+    var decodableType: WhiteboardObject.Type {
+        switch self {
+        case .text:
+            TextObject.self
+        case .photo:
+            PhotoObject.self
+        case .drawing:
+            DrawingObject.self
+        default:
+            WhiteboardObject.self
+        }
     }
 }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -23,19 +23,35 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
     public func send(whiteboardObject: WhiteboardObject, isDelete: Bool) async {
         switch whiteboardObject {
         case let textObject as TextObject:
-            await send(whiteboardObject: textObject, type: .text, isDelete: isDelete)
+            await send(
+                whiteboardObject: textObject,
+                type: .text,
+                isDelete: isDelete)
         case let drawingObject as DrawingObject:
-            await send(whiteboardObject: drawingObject, type: .drawing, isDelete: isDelete)
+            await send(
+                whiteboardObject: drawingObject,
+                type: .drawing,
+                isDelete: isDelete)
         case let photoObject as PhotoObject:
-            await send(whiteboardObject: photoObject, type: .photo, isDelete: isDelete)
+            await send(
+                whiteboardObject: photoObject,
+                type: .photo,
+                isDelete: isDelete)
         default:
             break
         }
     }
 
-    private func send(whiteboardObject: WhiteboardObject, type: AirplaINDataType, isDelete: Bool) async {
+    private func send(
+        whiteboardObject: WhiteboardObject,
+        type: AirplaINDataType,
+        isDelete: Bool
+    ) async {
         let objectData = try? JSONEncoder().encode(whiteboardObject)
-        let objectInformation = DataInformationDTO(id: whiteboardObject.id, type: type, isDelete: isDelete)
+        let objectInformation = DataInformationDTO(
+            id: whiteboardObject.id,
+            type: type,
+            isDelete: isDelete)
         guard let url = filePersistence
             .save(dataInfo: objectInformation, data: objectData)
         else {

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -20,26 +20,22 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
         self.nearbyNetwork.receiptDelegate = self
     }
 
-    public func send(whiteboardObject: WhiteboardObject) async {
+    public func send(whiteboardObject: WhiteboardObject, isDelete: Bool) async {
         switch whiteboardObject {
         case let textObject as TextObject:
-            await send(whiteboardObject: textObject, type: .text)
+            await send(whiteboardObject: textObject, type: .text, isDelete: isDelete)
         case let drawingObject as DrawingObject:
-            await send(whiteboardObject: drawingObject, type: .drawing)
+            await send(whiteboardObject: drawingObject, type: .drawing, isDelete: isDelete)
         case let photoObject as PhotoObject:
-            await send(whiteboardObject: photoObject, type: .photo)
+            await send(whiteboardObject: photoObject, type: .photo, isDelete: isDelete)
         default:
             break
         }
     }
 
-    public func delete(whiteboardObject: WhiteboardObject) {
-//        <#code#>
-    }
-
-    private func send(whiteboardObject: WhiteboardObject, type: AirplaINDataType) async {
+    private func send(whiteboardObject: WhiteboardObject, type: AirplaINDataType, isDelete: Bool) async {
         let objectData = try? JSONEncoder().encode(whiteboardObject)
-        let objectInformation = DataInformationDTO(id: whiteboardObject.id, type: type)
+        let objectInformation = DataInformationDTO(id: whiteboardObject.id, type: type, isDelete: isDelete)
         guard let url = filePersistence
             .save(dataInfo: objectInformation, data: objectData)
         else {
@@ -65,7 +61,12 @@ extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
             logger.log(level: .error, "WhiteboardObjectRepository: 전달받은 데이터 디코딩 실패")
             return
         }
-        delegate?.whiteboardObjectRepository(self, didReceive: whiteboardObject)
+
+        if info.isDelete {
+            delegate?.whiteboardObjectRepository(self, didDelete: whiteboardObject)
+        } else {
+            delegate?.whiteboardObjectRepository(self, didReceive: whiteboardObject)
+        }
     }
 }
 

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -20,23 +20,23 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
         self.nearbyNetwork.receiptDelegate = self
     }
 
-    public func send(whiteboardObject: WhiteboardObject, isDelete: Bool) async {
+    public func send(whiteboardObject: WhiteboardObject, isDeleted: Bool) async {
         switch whiteboardObject {
         case let textObject as TextObject:
             await send(
                 whiteboardObject: textObject,
                 type: .text,
-                isDelete: isDelete)
+                isDeleted: isDeleted)
         case let drawingObject as DrawingObject:
             await send(
                 whiteboardObject: drawingObject,
                 type: .drawing,
-                isDelete: isDelete)
+                isDeleted: isDeleted)
         case let photoObject as PhotoObject:
             await send(
                 whiteboardObject: photoObject,
                 type: .photo,
-                isDelete: isDelete)
+                isDeleted: isDeleted)
         default:
             break
         }
@@ -45,13 +45,13 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
     private func send(
         whiteboardObject: WhiteboardObject,
         type: AirplaINDataType,
-        isDelete: Bool
+        isDeleted: Bool
     ) async {
         let objectData = try? JSONEncoder().encode(whiteboardObject)
         let objectInformation = DataInformationDTO(
             id: whiteboardObject.id,
             type: type,
-            isDelete: isDelete)
+            isDeleted: isDeleted)
         guard let url = filePersistence
             .save(dataInfo: objectInformation, data: objectData)
         else {
@@ -82,7 +82,7 @@ extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
             return
         }
 
-        if info.isDelete {
+        if info.isDeleted {
             delegate?.whiteboardObjectRepository(self, didDelete: whiteboardObject)
         } else {
             delegate?.whiteboardObjectRepository(self, didReceive: whiteboardObject)

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -67,7 +67,11 @@ extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
         // TODO: 사용하지 않을 인터페이스로 예상
     }
 
-    public func nearbyNetwork(_ sender: any NearbyNetworkInterface, didReceiveURL URL: URL, info: DataInformationDTO) {
+    public func nearbyNetwork(
+        _ sender: any NearbyNetworkInterface,
+        didReceiveURL URL: URL,
+        info: DataInformationDTO
+    ) {
         guard let receiveData = filePersistence.load(path: URL) else { return }
         filePersistence.save(dataInfo: info, data: receiveData)
         guard let whiteboardObject = try? JSONDecoder().decode(

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -6,11 +6,21 @@
 //
 
 public protocol WhiteboardObjectRepositoryInterface {
-    /// 다른 사람이 보낸 화이트보드 오브젝트를 AsyncStream을 통해 전달하는 메서드
-    /// - Returns: WhiteboardObject들이 담겨 있는 AsyncStream
-    func whiteboardObjectAsyncStream() -> AsyncStream<WhiteboardObject>
+    /// WhiteboardObjectRepository의 delegate
+    var delegate: WhiteboardObjectRepositoryDelegate? { get set }
 
     /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
     /// - Parameter whiteboardObject: 전송할 Whiteboard Object
     func send(whiteboardObject: WhiteboardObject)
+
+    /// 텍스트 오브젝트를 삭제합니다.
+    /// - Parameter textObject: 삭제할 Whiteboard Object
+    func delete(whiteboardObject: WhiteboardObject)
+}
+
+public protocol WhiteboardObjectRepositoryDelegate: AnyObject {
+    /// 화이트보드 오브젝트를 수신하면 실행됩니다.
+    /// - Parameters:
+    ///   - object: 수신한 화이트보드 오브젝트
+    func whiteboardObjectRepository(_ sender: WhiteboardRepositoryInterface, didReceive object: WhiteboardObject)
 }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -22,10 +22,10 @@ public protocol WhiteboardObjectRepositoryDelegate: AnyObject {
     /// 화이트보드 오브젝트를 수신하면 실행됩니다.
     /// - Parameters:
     ///   - object: 추가되거나 수정된 화이트보드 오브젝트
-    func whiteboardObjectRepository(_ sender: WhiteboardRepositoryInterface, didReceive object: WhiteboardObject)
+    func whiteboardObjectRepository(_ sender: WhiteboardObjectRepositoryInterface, didReceive object: WhiteboardObject)
 
     /// 삭제된 화이트보드 오브젝트를 수신하면 실행됩니다.
     /// - Parameters:
     ///   - object: 삭제된 화이트보드 오브젝트
-    func whiteboardObjectRepository(_ sender: WhiteboardRepositoryInterface, didDelete object: WhiteboardObject)
+    func whiteboardObjectRepository(_ sender: WhiteboardObjectRepositoryInterface, didDelete object: WhiteboardObject)
 }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -21,6 +21,11 @@ public protocol WhiteboardObjectRepositoryInterface {
 public protocol WhiteboardObjectRepositoryDelegate: AnyObject {
     /// 화이트보드 오브젝트를 수신하면 실행됩니다.
     /// - Parameters:
-    ///   - object: 수신한 화이트보드 오브젝트
+    ///   - object: 추가되거나 수정된 화이트보드 오브젝트
     func whiteboardObjectRepository(_ sender: WhiteboardRepositoryInterface, didReceive object: WhiteboardObject)
+
+    /// 삭제된 화이트보드 오브젝트를 수신하면 실행됩니다.
+    /// - Parameters:
+    ///   - object: 삭제된 화이트보드 오브젝트
+    func whiteboardObjectRepository(_ sender: WhiteboardRepositoryInterface, didDelete object: WhiteboardObject)
 }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -11,7 +11,7 @@ public protocol WhiteboardObjectRepositoryInterface {
 
     /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
     /// - Parameter whiteboardObject: 전송할 Whiteboard Object
-    func send(whiteboardObject: WhiteboardObject)
+    func send(whiteboardObject: WhiteboardObject) async
 
     /// 텍스트 오브젝트를 삭제합니다.
     /// - Parameter textObject: 삭제할 Whiteboard Object

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -11,11 +11,7 @@ public protocol WhiteboardObjectRepositoryInterface {
 
     /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
     /// - Parameter whiteboardObject: 전송할 Whiteboard Object
-    func send(whiteboardObject: WhiteboardObject) async
-
-    /// 텍스트 오브젝트를 삭제합니다.
-    /// - Parameter textObject: 삭제할 Whiteboard Object
-    func delete(whiteboardObject: WhiteboardObject)
+    func send(whiteboardObject: WhiteboardObject, isDelete: Bool) async
 }
 
 public protocol WhiteboardObjectRepositoryDelegate: AnyObject {

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -11,7 +11,7 @@ public protocol WhiteboardObjectRepositoryInterface {
 
     /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
     /// - Parameter whiteboardObject: 전송할 Whiteboard Object
-    func send(whiteboardObject: WhiteboardObject, isDelete: Bool) async
+    func send(whiteboardObject: WhiteboardObject, isDeleted: Bool) async
 }
 
 public protocol WhiteboardObjectRepositoryDelegate: AnyObject {

--- a/Domain/Domain/Sources/UseCase/WhiteboardObjectSendUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardObjectSendUseCase.swift
@@ -14,7 +14,7 @@ public final class WhiteboardObjectSendUseCase: WhiteObjectSendUseCaseInterface 
 
     public func send(whiteboardObject: WhiteboardObject) {
         Task {
-            await repository.send(whiteboardObject: whiteboardObject)
+            await repository.send(whiteboardObject: whiteboardObject, isDelete: true)
         }
     }
 }

--- a/Domain/Domain/Sources/UseCase/WhiteboardObjectSendUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardObjectSendUseCase.swift
@@ -13,6 +13,8 @@ public final class WhiteboardObjectSendUseCase: WhiteObjectSendUseCaseInterface 
     }
 
     public func send(whiteboardObject: WhiteboardObject) {
-        repository.send(whiteboardObject: whiteboardObject)
+        Task {
+            await repository.send(whiteboardObject: whiteboardObject)
+        }
     }
 }

--- a/Domain/Domain/Sources/UseCase/WhiteboardObjectSendUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardObjectSendUseCase.swift
@@ -14,7 +14,7 @@ public final class WhiteboardObjectSendUseCase: WhiteObjectSendUseCaseInterface 
 
     public func send(whiteboardObject: WhiteboardObject) {
         Task {
-            await repository.send(whiteboardObject: whiteboardObject, isDelete: true)
+            await repository.send(whiteboardObject: whiteboardObject, isDeleted: true)
         }
     }
 }

--- a/Persistence/Persistence/Souces/FilePersistence.swift
+++ b/Persistence/Persistence/Souces/FilePersistence.swift
@@ -16,7 +16,7 @@ public struct FilePersistence: FilePersistenceInterface {
     }
     private let logger = Logger()
 
-    public func save(dataInfo: DataInformationDTO, data: Data) -> URL? {
+    public func save(dataInfo: DataInformationDTO, data: Data?) -> URL? {
         guard let directoryURL = documentDirectoryURL?
             .appendingPathComponent(
                 dataInfo
@@ -57,13 +57,13 @@ public struct FilePersistence: FilePersistenceInterface {
 
     private func write(
         to url: URL,
-        with data: Data,
+        with data: Data?,
         fileName: String
     ) -> URL {
         let fileURL = url.appendingPathComponent("\(fileName).json")
 
         do {
-            try data.write(to: fileURL)
+            try data?.write(to: fileURL)
         } catch {
             logger.log("FilePersistence: 파일 생성 실패 \(fileURL)")
         }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
WhiteboardObjectRepository를 설계하고 구현 했습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
[🖌️노션페이지](https://buttoned-package-f84.notion.site/144856db8fa0804db835ebd531ac7534?pvs=4)참고

노션페이지를 참고하면 데이터플로우를 쉽게 이해할 수 있습니다.
### https://github.com/boostcampwm-2024/iOS02-AirplaIN/commit/75977141f54fd78e9ab3b38db8de09983f99274e
화이트보드 오브젝트를 전송하는 레포지터리 로직을 구현 했습니다.
- 사용자가 데이터를 전송하기를 원했을 때, 전달받은 화이트보드오브젝트를 Encoding하여 로컬의 저장후 로컬 URL을 NearbyNetwork모듈에게 넘깁니다.
    - 이때 로컬에 저장할 때는 FilePersistence를 이용 
- NearbyNetwork에서 로컬URL을 받으면 해당 위치의 파일을 전송시키는 기능을 갖고 있습니다.

### https://github.com/boostcampwm-2024/iOS02-AirplaIN/commit/5193ab4538175f37f9842090890132cf40689dab
화이보드 오브젝트를 수신하는 레포지터리 로직을 구현 했습니다.
- NearbyNetwork모듈에서 수신한 데이터를 delegate를 통해 Repository로 전달 됩니다.
    - 이때 전달받은 데이터는 NearbyNetwork모듈에서 임의로 저장한 localURL에 존재합니다.
- 전달받은 localURL을 FilePersistence를 통해 전달받은 데이터를 받습니다.
- 데이터는 알맞는 local위치에 파일로 덮어씌어줍니다.
- 전달받은 데이터는 DataInformation을 통해 해당 Object로 Decoding해주어 WhiteboardObject를 생성합니다.
- 생성한 whiteboardObject를 delegate를 통해 Usecase에게 전달 해 줍니다

### https://github.com/boostcampwm-2024/iOS02-AirplaIN/pull/107/commits/13e9f80c0f4c4a5d9a2342addc0e7c6b00920880 https://github.com/boostcampwm-2024/iOS02-AirplaIN/pull/107/commits/19fa2e078cae38c87dd70d04a7c6fbc0e0f44ee5 https://github.com/boostcampwm-2024/iOS02-AirplaIN/pull/107/commits/08e40e0a194f95ad774fc7c1a8a1565b5c4df421
삭제를 구현하기위해 다른 Interface를 사용하지는 않았습니다.
전송과 수신 동작을 그대로 사용하여 해결하였습니다.
데이터를 보내거나 수신할 때 포함되는 DataInformationDTO를 이용해 구분 해 줄 수 있도록 구현 했습니다.

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
전달받은 임의의 localURL에 위치한 파일을 관리해주지 않고 있습니다.
이 파일을 어떻게 관리할지 정해보면 좋을 것 같습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #19 
- close #46 
- close #47  


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
