### PR TITLE
[Feature] 오브젝트 크기 변경 기능 추가

### DIFF
--- a/Domain/Domain/Sources/Entity/DrawingObject.swift
+++ b/Domain/Domain/Sources/Entity/DrawingObject.swift
@@ -17,8 +17,9 @@ public final class DrawingObject: WhiteboardObject {
 
     public init(
         id: UUID,
-        position: CGPoint,
+        centerPosition: CGPoint,
         size: CGSize,
+        scale: CGFloat = 1,
         points: [CGPoint],
         lineWidth: CGFloat,
         selectedBy: Profile? = nil
@@ -27,8 +28,9 @@ public final class DrawingObject: WhiteboardObject {
         self.lineWidth = lineWidth
         super.init(
             id: id,
-            position: position,
+            centerPosition: centerPosition,
             size: size,
+            scale: scale,
             selectedBy: selectedBy)
     }
 

--- a/Domain/Domain/Sources/Entity/PhotoObject.swift
+++ b/Domain/Domain/Sources/Entity/PhotoObject.swift
@@ -14,16 +14,18 @@ public final class PhotoObject: WhiteboardObject {
 
     public init(
         id: UUID,
-        position: CGPoint,
+        centerPosition: CGPoint,
         size: CGSize,
+        scale: CGFloat = 1,
         photoURL: URL,
         selectedBy: Profile? = nil
     ) {
         self.photoURL = photoURL
         super.init(
             id: id,
-            position: position,
+            centerPosition: centerPosition,
             size: size,
+            scale: scale,
             selectedBy: selectedBy)
     }
 

--- a/Domain/Domain/Sources/Entity/TextObject.swift
+++ b/Domain/Domain/Sources/Entity/TextObject.swift
@@ -14,16 +14,18 @@ public class TextObject: WhiteboardObject {
 
     public init(
         id: UUID,
-        position: CGPoint,
+        centerPosition: CGPoint,
         size: CGSize,
+        scale: CGFloat = 1,
         text: String,
         selectedBy: Profile? = nil
     ) {
         self.text = text
         super.init(
             id: id,
-            position: position,
+            centerPosition: centerPosition,
             size: size,
+            scale: scale,
             selectedBy: selectedBy)
     }
 

--- a/Domain/Domain/Sources/Entity/WhiteboardObject.swift
+++ b/Domain/Domain/Sources/Entity/WhiteboardObject.swift
@@ -8,20 +8,23 @@ import Foundation
 
 public class WhiteboardObject: Equatable, Codable {
     public let id: UUID
-    public private(set) var position: CGPoint
+    public private(set) var centerPosition: CGPoint
     public private(set) var size: CGSize
+    public private(set) var scale: CGFloat
     public private(set) var selectedBy: Profile?
     public private(set) var updatedAt: Date
 
     public init(
         id: UUID,
-        position: CGPoint,
+        centerPosition: CGPoint,
         size: CGSize,
+        scale: CGFloat = 1,
         selectedBy: Profile? = nil
     ) {
         self.id = id
-        self.position = position
+        self.centerPosition = centerPosition
         self.size = size
+        self.scale = scale
         self.selectedBy = selectedBy
         updatedAt = Date()
     }
@@ -38,6 +41,14 @@ public class WhiteboardObject: Equatable, Codable {
     func deselect() {
         selectedBy = nil
         updatedAt = Date()
+    }
+
+    func changeScale(to scale: CGFloat) {
+        self.scale = scale
+    }
+
+    func changePosition(position: CGPoint) {
+        self.centerPosition = position
     }
 }
 

--- a/Domain/Domain/Sources/Interface/UseCase/AddPhotoUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/AddPhotoUseCaseInterface.swift
@@ -12,12 +12,12 @@ public protocol AddPhotoUseCaseInterface {
     /// 사진 오브젝트를 추가합니다.
     /// - Parameters:
     ///   - imageData: 추가할 사진의 데이터
-    ///   - position: 사진을 추가할 위치 (origin)
+    ///   - centerPosition: 사진의 중심
     ///   - size: 사진 객체
     /// - Returns:
     func addPhoto(
         imageData: Data,
-        position: CGPoint,
+        centerPosition: CGPoint,
         size: CGSize
     ) throws -> PhotoObject
 }

--- a/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
@@ -40,10 +40,28 @@ public protocol ManageWhiteboardObjectUseCaseInterface {
 
     /// 화이트보드 오브젝트를 선택합니다.
     /// - Parameter whiteboardObject: 선택할 오브젝트
+    /// - Returns: 선택 성공 여부
     @discardableResult
     func select(whiteboardObjectID: UUID) async -> Bool
 
     /// 화이트보드 오브젝트를 선택 해제 합니다.
+    /// - Returns:  선택 해제 성공 여부
     @discardableResult
     func deselect() async -> Bool
+
+    /// 오브젝트의 위치를 변경합니다.
+    /// - Parameters:
+    ///   - whiteboardObjectID: 변경할 오브젝트의 ID
+    ///   - point: 변경할 object의 원점
+    /// - Returns: 위치 조정 성공 여부
+    @discardableResult
+    func changePosition(whiteboardObjectID: UUID, to point: CGPoint) async -> Bool
+
+    /// 오브젝트의 크기를 변경합니다.
+    /// - Parameters:
+    ///   - whiteboardObjectID: 변경할 오브젝트의 ID
+    ///   - point: 변경할 object의 크기
+    /// - Returns: 크기 조정 성공 여부
+    @discardableResult
+    func changeSize(whiteboardObjectID: UUID, to scale: CGFloat) async -> Bool
 }

--- a/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
@@ -12,8 +12,8 @@ public protocol TextObjectUseCaseInterface {
     /// TextObject를 생성하고 반환합니다.
     /// 현재 화면 중앙에 위치할 수 있도록 조절합니다.
     /// - Parameters:
-    ///   - scrollViewOffset: 현재 스크롤뷰가 보고있는 위치
-    ///   - viewSize: 현재 뷰의 크기
+    ///   - centerPoint: text오브젝트의 중심
+    ///   - size: 현재 뷰의 크기
     /// - Returns: 현재 화면 중앙에 위치한 TextObject를 반환
-    func addText(point: CGPoint, size: CGSize) -> TextObject
+    func addText(centerPoint: CGPoint, size: CGSize) -> TextObject
 }

--- a/Domain/Domain/Sources/UseCase/AddPhotoUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/AddPhotoUseCase.swift
@@ -31,7 +31,7 @@ public final class AddPhotoUseCase: AddPhotoUseCaseInterface {
 
     public func addPhoto(
         imageData: Data,
-        position: CGPoint,
+        centerPosition: CGPoint,
         size: CGSize
     ) throws -> PhotoObject {
         let uuid = UUID()
@@ -44,9 +44,14 @@ public final class AddPhotoUseCase: AddPhotoUseCaseInterface {
             throw DomainError.cannotWriteFile
         }
 
+        var size = size
+        let scaleFactor = size.width >= size.height ? 200 / size.width : 200 / size.height
+        size.width *= scaleFactor
+        size.height *= scaleFactor
+
         let photoObject = PhotoObject(
             id: uuid,
-            position: position,
+            centerPosition: centerPosition,
             size: size,
             photoURL: photoURL)
 

--- a/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
@@ -41,7 +41,7 @@ public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
             let minY = yPoints.min(),
             let maxY = yPoints.max()
         else { return nil }
-        
+
         let padding = lineWidth / 2
         let origin = CGPoint(x: minX - padding, y: minY - padding)
 

--- a/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/DrawObjectUseCase.swift
@@ -41,16 +41,25 @@ public final class DrawObjectUseCase: DrawObjectUseCaseInterface {
             let minY = yPoints.min(),
             let maxY = yPoints.max()
         else { return nil }
+        
         let padding = lineWidth / 2
         let origin = CGPoint(x: minX - padding, y: minY - padding)
-        let size = CGSize(width: maxX - minX + padding * 2, height: maxY - minY + padding * 2)
+
+        let size = CGSize(
+            width: maxX - minX + padding * 2,
+            height: maxY - minY + padding * 2)
+
+        let centerPosition = CGPoint(
+            x: origin.x + size.width / 2,
+            y: origin.y + size.height / 2)
+
         let adjustedPoints = points.map {
             CGPoint(x: $0.x - minX + padding, y: $0.y - minY + padding)
         }
 
         let drawingObject = DrawingObject(
             id: UUID(),
-            position: origin,
+            centerPosition: centerPosition,
             size: size,
             points: adjustedPoints,
             lineWidth: lineWidth)

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -14,7 +14,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
     public var removedObjectPublisher: AnyPublisher<WhiteboardObject, Never>
     public var selectedObjectIDPublisher: AnyPublisher<UUID?, Never>
 
-    private var whiteboardObjectStorage: WhiteboardObjectSet
+    private var whiteboardObjectSet: WhiteboardObjectSet
 
     private let addedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
     private let updatedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
@@ -37,18 +37,18 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         removedObjectPublisher = removedWhiteboardSubject.eraseToAnyPublisher()
         selectedObjectIDPublisher = selectedObjectIDSubject.eraseToAnyPublisher()
 
-        whiteboardObjectStorage = WhiteboardObjectSet()
+        whiteboardObjectSet = WhiteboardObjectSet()
         myProfile = profileRepository.loadProfile()
         self.whiteboardObjectRepository = whiteboardRepository
     }
 
     @discardableResult
     public func addObject(whiteboardObject: WhiteboardObject) async -> Bool {
-        let isContains = await whiteboardObjectStorage.contains(object: whiteboardObject)
+        let isContains = await whiteboardObjectSet.contains(object: whiteboardObject)
         guard !isContains else { return false }
 
         await whiteboardObjectRepository.send(whiteboardObject: whiteboardObject, isDeleted: false)
-        await whiteboardObjectStorage.insert(object: whiteboardObject)
+        await whiteboardObjectSet.insert(object: whiteboardObject)
         addedWhiteboardSubject.send(whiteboardObject)
 
         return true
@@ -56,11 +56,11 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func updateObject(whiteboardObject: WhiteboardObject) async -> Bool {
-        let isContains = await whiteboardObjectStorage.contains(object: whiteboardObject)
+        let isContains = await whiteboardObjectSet.contains(object: whiteboardObject)
         guard isContains else { return false }
 
         await whiteboardObjectRepository.send(whiteboardObject: whiteboardObject, isDeleted: false)
-        await whiteboardObjectStorage.update(object: whiteboardObject)
+        await whiteboardObjectSet.update(object: whiteboardObject)
         updatedWhiteboardSubject.send(whiteboardObject)
 
         return true
@@ -68,11 +68,11 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func removeObject(whiteboardObject: WhiteboardObject) async -> Bool {
-        let isContains = await whiteboardObjectStorage.contains(object: whiteboardObject)
+        let isContains = await whiteboardObjectSet.contains(object: whiteboardObject)
         guard isContains else { return false }
 
         await whiteboardObjectRepository.send(whiteboardObject: whiteboardObject, isDeleted: true)
-        await whiteboardObjectStorage.remove(object: whiteboardObject)
+        await whiteboardObjectSet.remove(object: whiteboardObject)
         removedWhiteboardSubject.send(whiteboardObject)
 
         return true
@@ -83,7 +83,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         await deselect()
 
         guard
-            let object = await whiteboardObjectStorage.fetchObjectByID(id: whiteboardObjectID),
+            let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID),
             object.selectedBy == nil
         else { return false }
 
@@ -98,13 +98,27 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         guard let selectedObjectID = selectedObjectIDSubject.value else { return false }
 
         guard
-            let selectedObject = await whiteboardObjectStorage.fetchObjectByID(id: selectedObjectID),
+            let selectedObject = await whiteboardObjectSet.fetchObjectByID(id: selectedObjectID),
             selectedObject.selectedBy == myProfile
         else { return false }
 
         selectedObject.deselect()
         await updateObject(whiteboardObject: selectedObject)
         return true
+    }
+
+    @discardableResult
+    public func changeSize(whiteboardObjectID: UUID, to scale: CGFloat) async -> Bool {
+        guard let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID) else { return false }
+        object.changeScale(to: scale)
+        return await updateObject(whiteboardObject: object)
+    }
+
+    @discardableResult
+    public func changePosition(whiteboardObjectID: UUID, to position: CGPoint) async -> Bool {
+        guard let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID) else { return false }
+        object.changePosition(position: position)
+        return await updateObject(whiteboardObject: object)
     }
 }
 
@@ -114,7 +128,7 @@ extension ManageWhiteboardObjectUseCase: WhiteboardObjectRepositoryDelegate {
         didReceive object: WhiteboardObject
     ) {
         Task {
-            let isContains = await whiteboardObjectStorage.contains(object: object)
+            let isContains = await whiteboardObjectSet.contains(object: object)
 
             if isContains {
                 await updateObject(whiteboardObject: object)

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -109,14 +109,22 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func changeSize(whiteboardObjectID: UUID, to scale: CGFloat) async -> Bool {
-        guard let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID) else { return false }
+        guard
+            let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID),
+            object.selectedBy == myProfile
+        else { return false }
+
         object.changeScale(to: scale)
         return await updateObject(whiteboardObject: object)
     }
 
     @discardableResult
     public func changePosition(whiteboardObjectID: UUID, to position: CGPoint) async -> Bool {
-        guard let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID) else { return false }
+        guard
+            let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID),
+            object.selectedBy == myProfile
+        else { return false }
+
         object.changePosition(position: position)
         return await updateObject(whiteboardObject: object)
     }

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -16,14 +16,9 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
     }
 
     public func addText(centerPoint point: CGPoint, size: CGSize) -> TextObject {
-        let positionX = point.x + size.width / 3
-        let positionY = point.y + size.height / 3
-        let centerPosition = CGPoint(
-            x: positionX + size.width / 2,
-            y: positionY + size.height / 2)
         return TextObject(
             id: UUID(),
-            centerPosition: centerPosition,
+            centerPosition: point,
             size: textFieldDefaultSize,
             text: "")
     }

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -15,13 +15,15 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
         self.textFieldDefaultSize = textFieldDefaultSize
     }
 
-    public func addText(point: CGPoint, size: CGSize) -> TextObject {
+    public func addText(centerPoint point: CGPoint, size: CGSize) -> TextObject {
         let positionX = point.x + size.width / 3
         let positionY = point.y + size.height / 3
-        let position = CGPoint(x: positionX, y: positionY)
+        let centerPosition = CGPoint(
+            x: positionX + size.width / 2,
+            y: positionY + size.height / 2)
         return TextObject(
             id: UUID(),
-            position: position,
+            centerPosition: centerPosition,
             size: textFieldDefaultSize,
             text: "")
     }

--- a/Domain/DomainTests/AddPhotoUseCaseTests.swift
+++ b/Domain/DomainTests/AddPhotoUseCaseTests.swift
@@ -38,7 +38,7 @@ final class AddPhotoUseCaseTests: XCTestCase {
         do {
             photoObject = try useCase.addPhoto(
                 imageData: dummyImageData,
-                position: position,
+                centerPosition: position,
                 size: size)
         } catch {
             XCTFail("photoObject should not fail.")
@@ -47,7 +47,7 @@ final class AddPhotoUseCaseTests: XCTestCase {
 
         // 검증
         XCTAssertEqual(photoObject.photoURL.lastPathComponent.suffix(4), ".jpg")
-        XCTAssertEqual(photoObject.position, position)
+        XCTAssertEqual(photoObject.centerPosition, position)
         XCTAssertEqual(photoObject.size, size)
     }
 }

--- a/Domain/DomainTests/DrawObjectUseCaseTests.swift
+++ b/Domain/DomainTests/DrawObjectUseCaseTests.swift
@@ -55,7 +55,7 @@ final class DrawObjectUseCaseTests: XCTestCase {
 
          // 검증
          XCTAssertNotNil(drawingObject)
-         XCTAssertEqual(drawingObject?.position, CGPoint(x: 10 - padding, y: 10 - padding))
+         XCTAssertEqual(drawingObject?.centerPosition, CGPoint(x: 10 - padding, y: 10 - padding))
          XCTAssertEqual(drawingObject?.size, CGSize(width: 3 + padding * 2, height: 3 + padding * 2))
          XCTAssertEqual(drawingObject?.points, expectedAdjustedPoints)
      }

--- a/Domain/DomainTests/DrawObjectUseCaseTests.swift
+++ b/Domain/DomainTests/DrawObjectUseCaseTests.swift
@@ -39,23 +39,28 @@ final class DrawObjectUseCaseTests: XCTestCase {
     // finishDrawing이 올바르게 DrawingObject를 생성하는지 확인
      func testFinishDrawingCreatesAndSendsDrawingObject() {
          // 준비
-         useCase.startDrawing(at: CGPoint(x: 10, y: 10))
-         useCase.addPoint(point: CGPoint(x: 11, y: 11))
-         useCase.addPoint(point: CGPoint(x: 12, y: 12))
-         useCase.addPoint(point: CGPoint(x: 13, y: 13))
+         let points: [CGPoint] = [
+            CGPoint(x: 10, y: 10),
+            CGPoint(x: 11, y: 11),
+            CGPoint(x: 12, y: 12),
+            CGPoint(x: 13, y: 13)
+         ]
+         useCase.startDrawing(at: points[0])
+         points.dropFirst().forEach { useCase.addPoint(point: $0) }
          let padding = lineWidth / 2
          let expectedAdjustedPoints = [
              CGPoint(x: 0 + padding, y: 0 + padding),
              CGPoint(x: 1 + padding, y: 1 + padding),
              CGPoint(x: 2 + padding, y: 2 + padding),
              CGPoint(x: 3 + padding, y: 3 + padding)]
+         let centerPoint = calculateMidPoint(from: points)
 
          // 실행
          let drawingObject = useCase.finishDrawing()
 
          // 검증
          XCTAssertNotNil(drawingObject)
-         XCTAssertEqual(drawingObject?.centerPosition, CGPoint(x: 10 - padding, y: 10 - padding))
+         XCTAssertEqual(drawingObject?.centerPosition, centerPoint)
          XCTAssertEqual(drawingObject?.size, CGSize(width: 3 + padding * 2, height: 3 + padding * 2))
          XCTAssertEqual(drawingObject?.points, expectedAdjustedPoints)
      }
@@ -72,5 +77,13 @@ final class DrawObjectUseCaseTests: XCTestCase {
 
         // 검증
         XCTAssertEqual(useCase.points.count, 0)
+    }
+
+    private func calculateMidPoint(from points: [CGPoint]) -> CGPoint {
+        guard !points.isEmpty else { return .zero }
+
+        let total = points.reduce(CGPoint.zero) { CGPoint(x: $0.x + $1.x, y: $0.y + $1.y) }
+        let count = CGFloat(points.count)
+        return CGPoint(x: total.x / count, y: total.y / count)
     }
 }

--- a/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
+++ b/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
@@ -33,7 +33,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
         var receivedObject: WhiteboardObject?
 
@@ -54,7 +54,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
 
         // 실행
@@ -72,11 +72,11 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         let uuid = UUID()
         let object = WhiteboardObject(
             id: uuid,
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
         let updatedObject = WhiteboardObject(
             id: uuid,
-            position: CGPoint(x: 50, y: 50),
+            centerPosition: CGPoint(x: 50, y: 50),
             size: CGSize(width: 200, height: 200))
         var receivedObject: WhiteboardObject?
 
@@ -98,7 +98,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: CGPoint(x: 50, y: 50),
+            centerPosition: CGPoint(x: 50, y: 50),
             size: CGSize(width: 200, height: 200))
         var receivedObject: WhiteboardObject?
 
@@ -119,15 +119,15 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let object1 = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
         let object2 = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
         var receivedObject: WhiteboardObject?
 
@@ -151,7 +151,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let object = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100))
         var receivedObject: WhiteboardObject?
 
@@ -172,7 +172,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100),
             selectedBy: nil)
 
@@ -192,7 +192,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         let strangerProfile = Profile(nickname: "strangerProfile", profileIcon: .cold)
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100),
             selectedBy: strangerProfile)
 
@@ -228,7 +228,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         // 준비
         let targetObject = WhiteboardObject(
             id: UUID(),
-            position: .zero,
+            centerPosition: .zero,
             size: CGSize(width: 100, height: 100),
             selectedBy: nil)
 
@@ -241,6 +241,60 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
         XCTAssertTrue(isSuccess)
     }
 
+    // 오브젝트 scale 변경 성공하는지 테스트
+    func testChangeScaleSuccess() async {
+        // 준비
+        let targetObject = WhiteboardObject(
+            id: UUID(),
+            centerPosition: .zero,
+            size: CGSize(width: 100, height: 100),
+            selectedBy: myProfile)
+
+        // 실행
+        await useCase.addObject(whiteboardObject: targetObject)
+        let isSuccess = await useCase.changeSize(whiteboardObjectID: targetObject.id, to: 2)
+
+        // 검증
+        XCTAssertTrue(isSuccess)
+        XCTAssertEqual(targetObject.scale, 2)
+    }
+
+    // 다른 사람이 선택 중일 때 scale 변경 실패하는지 테스트
+    func testChangeScaleFailsWhenSelectedByOther() async {
+        // 준비
+        let strangerProfile = Profile(nickname: "Other", profileIcon: .cold)
+        let targetObject = WhiteboardObject(
+            id: UUID(),
+            centerPosition: .zero,
+            size: CGSize(width: 100, height: 100),
+            selectedBy: strangerProfile)
+
+        // 실행
+        await useCase.addObject(whiteboardObject: targetObject)
+        let isFailure = await !useCase.changeSize(whiteboardObjectID: targetObject.id, to: 2)
+
+        // 검증
+        XCTAssertTrue(isFailure)
+        XCTAssertEqual(targetObject.scale, 1)
+    }
+
+    // 선택하지 않은 상태라 scale 변경 실패하는지 테스트
+    func testChangeScaleFailsWhenNotSelected() async {
+        // 준비
+        let targetObject = WhiteboardObject(
+            id: UUID(),
+            centerPosition: .zero,
+            size: CGSize(width: 100, height: 100),
+            selectedBy: nil)
+
+        // 실행
+        await useCase.addObject(whiteboardObject: targetObject)
+        let isFailure = await !useCase.changeSize(whiteboardObjectID: targetObject.id, to: 2)
+
+        // 검증
+        XCTAssertTrue(isFailure)
+        XCTAssertEqual(targetObject.scale, 1)
+    }
     // TODO: - 객체 수신, 삭제 테스트 코드 추가
 }
 

--- a/Domain/DomainTests/TextObjectUseCaseTests.swift
+++ b/Domain/DomainTests/TextObjectUseCaseTests.swift
@@ -34,7 +34,7 @@ final class TextObjectUseCaseTests: XCTestCase {
         let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
 
         // 검증
-        XCTAssertEqual(createdTextObject.position, expectedPosition)
+        XCTAssertEqual(createdTextObject.centerPosition, expectedPosition)
     }
 
     // addText테스트
@@ -51,7 +51,7 @@ final class TextObjectUseCaseTests: XCTestCase {
         let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
 
         // 검증
-        XCTAssertEqual(createdTextObject.position, expectedPosition)
+        XCTAssertEqual(createdTextObject.centerPosition, expectedPosition)
     }
 
     // addText테스트
@@ -68,7 +68,7 @@ final class TextObjectUseCaseTests: XCTestCase {
         let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
 
         // 검증
-        XCTAssertEqual(createdTextObject.position, expectedPosition)
+        XCTAssertEqual(createdTextObject.centerPosition, expectedPosition)
     }
 
 }

--- a/Domain/DomainTests/TextObjectUseCaseTests.swift
+++ b/Domain/DomainTests/TextObjectUseCaseTests.swift
@@ -24,14 +24,11 @@ final class TextObjectUseCaseTests: XCTestCase {
     // 정상적인 입력
     func testIdealAddText() {
         // 준비
-        let testScrollViewOffset = CGPoint(x: 0, y: 0)
+        let testScrollViewOffset = CGPoint(x: 100, y: 100)
         let testViewSize = CGSize(width: 300, height: 300)
-        let expectedPosition = CGPoint(
-            x: testScrollViewOffset.x + testViewSize.width / 3,
-            y: testScrollViewOffset.y + testViewSize.height / 3)
-
+        let expectedPosition = CGPoint(x: 100, y: 100)
         // 실행
-        let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
+        let createdTextObject = useCase.addText(centerPoint: testScrollViewOffset, size: testViewSize)
 
         // 검증
         XCTAssertEqual(createdTextObject.centerPosition, expectedPosition)
@@ -43,12 +40,10 @@ final class TextObjectUseCaseTests: XCTestCase {
         // 준비
         let testScrollViewOffset = CGPoint(x: 0, y: 0)
         let testViewSize = CGSize(width: 0, height: 0)
-        let expectedPosition = CGPoint(
-            x: testScrollViewOffset.x + testViewSize.width / 3,
-            y: testScrollViewOffset.y + testViewSize.height / 3)
+        let expectedPosition = CGPoint(x: 0, y: 0)
 
         // 실행
-        let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
+        let createdTextObject = useCase.addText(centerPoint: testScrollViewOffset, size: testViewSize)
 
         // 검증
         XCTAssertEqual(createdTextObject.centerPosition, expectedPosition)
@@ -60,12 +55,10 @@ final class TextObjectUseCaseTests: XCTestCase {
         // 준비
         let testScrollViewOffset = CGPoint(x: 0, y: 0)
         let testViewSize = CGSize(width: -300, height: -300)
-        let expectedPosition = CGPoint(
-            x: testScrollViewOffset.x + testViewSize.width / 3,
-            y: testScrollViewOffset.y + testViewSize.height / 3)
+        let expectedPosition = CGPoint(x: 0, y: 0)
 
         // 실행
-        let createdTextObject = useCase.addText(point: testScrollViewOffset, size: testViewSize)
+        let createdTextObject = useCase.addText(centerPoint: testScrollViewOffset, size: testViewSize)
 
         // 검증
         XCTAssertEqual(createdTextObject.centerPosition, expectedPosition)

--- a/Presentation/Presentation/Resources/Colors.xcassets/AirplainWhite.colorset/Contents.json
+++ b/Presentation/Presentation/Resources/Colors.xcassets/AirplainWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
@@ -8,24 +8,29 @@ import Domain
 import Foundation
 
 public protocol WhiteboardObjectViewFactoryable {
+    var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate? { get set }
     func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView?
 }
 
 public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
-    public init() {}
+    public weak var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate?
 
     public func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView? {
+        let whiteboardObjectView: WhiteboardObjectView?
+
         switch whiteboardObject {
         case let textObject as TextObject:
-            return TextObjectView(textObject: textObject)
+            whiteboardObjectView = TextObjectView(textObject: textObject)
         case let drawingObject as DrawingObject:
-            return DrawingObjectView(drawingObject: drawingObject)
+            whiteboardObjectView = DrawingObjectView(drawingObject: drawingObject)
         case let photoObject as PhotoObject:
-            return PhotoObjectView(photoObject: photoObject)
+            whiteboardObjectView = PhotoObjectView(photoObject: photoObject)
+
         default:
-            break
+            whiteboardObjectView = nil
         }
 
-        return nil
+        whiteboardObjectView?.delegate = whiteboardObjectViewDelegate
+        return whiteboardObjectView
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
@@ -22,10 +22,11 @@ final class DrawingObjectView: WhiteboardObjectView {
         super.init(coder: coder)
     }
 
-    private func configureLayout() {
+    override func configureLayout() {
         imageView
             .addToSuperview(self)
             .edges(equalTo: self)
+        super.configureLayout()
     }
 
     private func renderImage(with object: DrawingObject) {

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
@@ -13,7 +13,6 @@ final class PhotoObjectView: WhiteboardObjectView {
 
     init(photoObject: PhotoObject) {
         super.init(whiteboardObject: photoObject)
-        configureFrame(photoObject: photoObject)
         configureAttribute()
         configureLayout()
         configureImage(with: photoObject)
@@ -21,17 +20,6 @@ final class PhotoObjectView: WhiteboardObjectView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-    }
-
-    override func update(with whiteboardObject: WhiteboardObject) {
-        guard let photoObject = whiteboardObject as? PhotoObject else { return }
-        configureFrame(photoObject: photoObject)
-
-        if let selector = photoObject.selectedBy {
-            select(selector: selector)
-        } else {
-            deselect()
-        }
     }
 
     private func configureAttribute() {
@@ -43,21 +31,6 @@ final class PhotoObjectView: WhiteboardObjectView {
             .addToSuperview(self)
             .edges(equalTo: self)
         super.configureLayout()
-    }
-
-    private func configureFrame(photoObject: PhotoObject) {
-        var width = photoObject.size.width
-        var height = photoObject.size.height
-        let scaleFactor: CGFloat = width >= height ? 200 / width : 200 / height
-        width *= scaleFactor
-        height *= scaleFactor
-
-        let frame = CGRect(
-            x: photoObject.position.x - width / 2,
-            y: photoObject.position.y - height / 2,
-            width: width,
-            height: height)
-        self.frame = frame
     }
 
     private func configureImage(with object: PhotoObject) {

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
@@ -38,10 +38,11 @@ final class PhotoObjectView: WhiteboardObjectView {
         imageView.contentMode = .scaleAspectFit
     }
 
-    private func configureLayout() {
+    override func configureLayout() {
         imageView
             .addToSuperview(self)
             .edges(equalTo: self)
+        super.configureLayout()
     }
 
     private func configureFrame(photoObject: PhotoObject) {

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -11,6 +11,7 @@ import UIKit
 final class TextObjectView: WhiteboardObjectView {
     private let textField: UITextField = {
         let textField = UITextField()
+        textField.textAlignment = .center
         textField.placeholder = "Hello AirplaIN"
         return textField
     }()

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -34,10 +34,11 @@ final class TextObjectView: WhiteboardObjectView {
         textField.backgroundColor = .clear
     }
 
-    private func configureLayout() {
+    override func configureLayout() {
         textField
             .addToSuperview(self)
             .edges(equalTo: self)
+        super.configureLayout()
     }
 
     override func update(with object: WhiteboardObject) {

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardObjectView.swift
@@ -10,6 +10,8 @@ import UIKit
 public class WhiteboardObjectView: UIView {
     private enum WhiteboardObjectViewLayoutConstant {
         static let profileIconSize: CGFloat = 30
+        static let controlViewSize: CGFloat = 30
+        static let controlViewInset: CGFloat = 5
         static let selectorViewBorderWidth: CGFloat = 5
     }
 
@@ -22,13 +24,35 @@ public class WhiteboardObjectView: UIView {
         ]
         return profileIconView
     }()
+
+    private let controlView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = WhiteboardObjectViewLayoutConstant.controlViewSize / 2
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.airplainBlack.cgColor
+        view.backgroundColor = .airplainWhite
+        view.isHidden = true
+        return view
+    }()
+
+    private let controlImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "arrow.up.left.and.arrow.down.right")
+        imageView.tintColor = .airplainBlack
+        return imageView
+    }()
+
+    private let borderLayer: CALayer
     let objectId: UUID
 
     init(whiteboardObject: WhiteboardObject) {
         objectId = whiteboardObject.id
         let frame = CGRect(origin: whiteboardObject.position, size: whiteboardObject.size)
+        borderLayer = CALayer()
         super.init(frame: frame)
         backgroundColor = .clear
+        configureBorderLayer()
         configureLayout()
         if let selector = whiteboardObject.selectedBy {
             select(selector: selector)
@@ -37,35 +61,65 @@ public class WhiteboardObjectView: UIView {
 
     required init?(coder: NSCoder) {
         objectId = UUID()
+        borderLayer = CALayer()
         super.init(coder: coder)
+        configureBorderLayer()
         configureLayout()
     }
 
-    private func configureLayout() {
+    func configureLayout() {
         profileIconView
             .addToSuperview(self)
-            .trailing(equalTo: self.leadingAnchor, inset: .zero)
-            .bottom(equalTo: self.topAnchor, inset: .zero)
+            .trailing(equalTo: leadingAnchor, inset: .zero)
+            .bottom(equalTo: topAnchor, inset: .zero)
             .size(
                 width: WhiteboardObjectViewLayoutConstant.profileIconSize,
                 height: WhiteboardObjectViewLayoutConstant.profileIconSize)
+
+        controlView
+            .addToSuperview(self)
+            .leading(
+                equalTo: trailingAnchor,
+                constant: -WhiteboardObjectViewLayoutConstant.controlViewSize / 2)
+            .top(
+                equalTo: bottomAnchor,
+                constant: -WhiteboardObjectViewLayoutConstant.controlViewSize / 2)
+            .size(
+                width: WhiteboardObjectViewLayoutConstant.controlViewSize,
+                height: WhiteboardObjectViewLayoutConstant.controlViewSize)
+
+        controlImageView
+            .addToSuperview(controlView)
+            .edges(
+                equalTo: controlView,
+                inset: WhiteboardObjectViewLayoutConstant.controlViewInset)
+    }
+
+    private func configureBorderLayer() {
+        borderLayer.borderWidth = WhiteboardObjectViewLayoutConstant.selectorViewBorderWidth
+        layer.addSublayer(borderLayer)
     }
 
     func select(selector: Profile) {
+        CATransaction.setAnimationDuration(0)
         let profileIcon = selector.profileIcon
         let colorHex = profileIcon.colorHex
         let profileColor = UIColor(hex: colorHex)
-        layer.borderWidth = WhiteboardObjectViewLayoutConstant.selectorViewBorderWidth
-        layer.borderColor = profileColor.cgColor
         profileIconView.configure(
             profileIcon: profileIcon,
             profileIconSize: WhiteboardObjectViewLayoutConstant.profileIconSize)
         profileIconView.isHidden = false
+        controlView.isHidden = false
+        borderLayer.frame = calculateBorderFrame()
+        borderLayer.borderColor = profileColor.cgColor
+        borderLayer.isHidden = false
     }
 
     func deselect() {
+        CATransaction.setAnimationDuration(0)
         profileIconView.isHidden = true
-        layer.borderWidth = .zero
+        controlView.isHidden = true
+        borderLayer.isHidden = true
     }
 
     func update(with object: WhiteboardObject) {
@@ -78,5 +132,16 @@ public class WhiteboardObjectView: UIView {
         } else {
             deselect()
         }
+    }
+
+    private func calculateBorderFrame() -> CGRect {
+        let origin = CGPoint(
+            x: .zero - WhiteboardObjectViewLayoutConstant.selectorViewBorderWidth,
+            y: .zero - WhiteboardObjectViewLayoutConstant.selectorViewBorderWidth)
+        let size = CGSize(
+            width: bounds.width + WhiteboardObjectViewLayoutConstant.selectorViewBorderWidth * 2,
+            height: bounds.height + WhiteboardObjectViewLayoutConstant.selectorViewBorderWidth * 2)
+
+        return CGRect(origin: origin, size: size)
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 오브젝트 크기 변경 기능 추가

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- iPhone SE3

https://github.com/user-attachments/assets/e308143d-f9ea-4632-bfa3-863c68cb60b0


- iPhone 13 mini

https://github.com/user-attachments/assets/98084da3-3726-4b3c-85fe-105ce21aec45


- iPhone 16 Pro


https://github.com/user-attachments/assets/9d01ad03-d82b-48ef-8b5f-4cade76722e7



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 작업 내용
- 크기 수정 UI 구현
- 크기 수정 기능 추가
    - 크기 수정하는 view (ControlView)에 pan gesture를 추가했는데요, superView의 scrollView 때문에 pangesture가 원하는대로 동작하지 않는 문제가 있었습니다.
    - 해당 pangestrue가 실행될 때 다른 gesture를 비활성화 하였습니다.
    - 또 ControlView의 일부 영역 (3/4 정도에 해당하는 영역)이 오브젝트 뷰의 frame 영역 밖에 위치하기 때문에, pangesture가 인식되지 않는 문제가 있었습니다.
    - hittest를 override하여 터치 한 곳이 controlView 안이라면, pangesture가 정상적으로 동작할 수 있도록 구현했습니다.

### 주요 변경 사항
- 이전에는 화이트보드 오브젝트 엔티티의 position은 추가될 view에서의 origin이었습니다.
- CGAffineTransform으로 scale을 변환할 때, origin이 아닌 view의 center를 anchor로 하여 변환하기 때문에, origin으로 오브젝트의 정확한 좌표를 나타내기 힘들다는 문제가 있었습니다. scale 변경만 할 때는 상관이 없지만, scale 변경 후 오브젝트 위치를 바꾸면 역산 후 올바른 오브젝트 view를 화면에 표시하는 것이 복잡하다고 느꼈습니다.
- 따라서 화이트보드 오브젝트 엔티티의 position이 origin이 아닌, center를 나타내도록 수정하였습니다. 이에 따라 많은 도메인 코드를 수정해야 했습니다. 
- 표시 될 때 나타나는 boarder가 이전에는 내부 content를 침범하지 않도록 약간의 여유를 두고 표시했었습니다. 때문에 확대/축소 할 때 여유로 둔 간격때문에 선택한 사람을 나타내는 profileView와 확대/축소를 진행하는 controlView가 정상적인 위치에 표시되지 않는 문제가 있었습니다. 따라서 이제 boarder layer가 정확히 objectView와 같은 테두리에 표시됩니다. **(반나절 삽질의 원인 1순위)**

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 코드 실행

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 어제 후딱 끝낼 수 있을 줄 알았는데 scale 고려하니까 고려할 좌표 변환, 계산이 너무 많아 오래 걸렸습니다..

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #28
- close #31

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
