### PR TITLE
[Feature] 화이트보드 오브젝트 위치 수정, 각도 수정 기능 구현

### DIFF
--- a/Domain/Domain/Sources/Entity/DrawingObject.swift
+++ b/Domain/Domain/Sources/Entity/DrawingObject.swift
@@ -20,6 +20,7 @@ public final class DrawingObject: WhiteboardObject {
         centerPosition: CGPoint,
         size: CGSize,
         scale: CGFloat = 1,
+        angle: CGFloat = 0,
         points: [CGPoint],
         lineWidth: CGFloat,
         selectedBy: Profile? = nil
@@ -31,6 +32,7 @@ public final class DrawingObject: WhiteboardObject {
             centerPosition: centerPosition,
             size: size,
             scale: scale,
+            angle: angle,
             selectedBy: selectedBy)
     }
 

--- a/Domain/Domain/Sources/Entity/PhotoObject.swift
+++ b/Domain/Domain/Sources/Entity/PhotoObject.swift
@@ -17,6 +17,7 @@ public final class PhotoObject: WhiteboardObject {
         centerPosition: CGPoint,
         size: CGSize,
         scale: CGFloat = 1,
+        angle: CGFloat = 0,
         photoURL: URL,
         selectedBy: Profile? = nil
     ) {
@@ -26,6 +27,7 @@ public final class PhotoObject: WhiteboardObject {
             centerPosition: centerPosition,
             size: size,
             scale: scale,
+            angle: angle,
             selectedBy: selectedBy)
     }
 

--- a/Domain/Domain/Sources/Entity/TextObject.swift
+++ b/Domain/Domain/Sources/Entity/TextObject.swift
@@ -17,6 +17,7 @@ public class TextObject: WhiteboardObject {
         centerPosition: CGPoint,
         size: CGSize,
         scale: CGFloat = 1,
+        angle: CGFloat = 0,
         text: String,
         selectedBy: Profile? = nil
     ) {
@@ -26,6 +27,7 @@ public class TextObject: WhiteboardObject {
             centerPosition: centerPosition,
             size: size,
             scale: scale,
+            angle: angle,
             selectedBy: selectedBy)
     }
 

--- a/Domain/Domain/Sources/Entity/WhiteboardObject.swift
+++ b/Domain/Domain/Sources/Entity/WhiteboardObject.swift
@@ -11,6 +11,7 @@ public class WhiteboardObject: Equatable, Codable {
     public private(set) var centerPosition: CGPoint
     public private(set) var size: CGSize
     public private(set) var scale: CGFloat
+    public private(set) var angle: CGFloat
     public private(set) var selectedBy: Profile?
     public private(set) var updatedAt: Date
 
@@ -19,12 +20,14 @@ public class WhiteboardObject: Equatable, Codable {
         centerPosition: CGPoint,
         size: CGSize,
         scale: CGFloat = 1,
+        angle: CGFloat = 0,
         selectedBy: Profile? = nil
     ) {
         self.id = id
         self.centerPosition = centerPosition
         self.size = size
         self.scale = scale
+        self.angle = angle
         self.selectedBy = selectedBy
         updatedAt = Date()
     }
@@ -49,6 +52,10 @@ public class WhiteboardObject: Equatable, Codable {
 
     func changePosition(position: CGPoint) {
         self.centerPosition = position
+    }
+
+    func changeAngle(to angle: CGFloat) {
+        self.angle = angle
     }
 }
 

--- a/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
@@ -68,6 +68,4 @@ public protocol ManageWhiteboardObjectUseCaseInterface {
         whiteboardObjectID: UUID,
         scale: CGFloat,
         angle: CGFloat) async -> Bool
-
-
 }

--- a/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
@@ -57,11 +57,17 @@ public protocol ManageWhiteboardObjectUseCaseInterface {
     @discardableResult
     func changePosition(whiteboardObjectID: UUID, to point: CGPoint) async -> Bool
 
-    /// 오브젝트의 크기를 변경합니다.
+    /// 화이트보드 오브젝트의 크기와 회전 각도를 변경합니다.
     /// - Parameters:
     ///   - whiteboardObjectID: 변경할 오브젝트의 ID
-    ///   - point: 변경할 object의 크기
-    /// - Returns: 크기 조정 성공 여부
+    ///   - scale: 변경할 크기 (옵셔널)
+    ///   - angle: 변경할 각도 (옵셔널)
+    /// - Returns: 변경 성공 여부
     @discardableResult
-    func changeSize(whiteboardObjectID: UUID, to scale: CGFloat) async -> Bool
+    func changeSizeAndAngle(
+        whiteboardObjectID: UUID,
+        scale: CGFloat,
+        angle: CGFloat) async -> Bool
+
+
 }

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -108,13 +108,19 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
     }
 
     @discardableResult
-    public func changeSize(whiteboardObjectID: UUID, to scale: CGFloat) async -> Bool {
+    public func changeSizeAndAngle(
+        whiteboardObjectID: UUID,
+        scale: CGFloat,
+        angle: CGFloat
+    ) async -> Bool {
         guard
             let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID),
             object.selectedBy == myProfile
         else { return false }
 
         object.changeScale(to: scale)
+        object.changeAngle(to: angle)
+
         return await updateObject(whiteboardObject: object)
     }
 

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -44,8 +44,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func addObject(whiteboardObject: WhiteboardObject) async -> Bool {
-        let isContains = await whiteboardObjectSet.contains(object: whiteboardObject)
-        guard !isContains else { return false }
+        guard await !whiteboardObjectSet.contains(object: whiteboardObject) else { return false }
 
         await whiteboardObjectRepository.send(whiteboardObject: whiteboardObject, isDeleted: false)
         await whiteboardObjectSet.insert(object: whiteboardObject)
@@ -56,8 +55,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func updateObject(whiteboardObject: WhiteboardObject) async -> Bool {
-        let isContains = await whiteboardObjectSet.contains(object: whiteboardObject)
-        guard isContains else { return false }
+        guard await whiteboardObjectSet.contains(object: whiteboardObject) else { return false }
 
         await whiteboardObjectRepository.send(whiteboardObject: whiteboardObject, isDeleted: false)
         await whiteboardObjectSet.update(object: whiteboardObject)
@@ -68,8 +66,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func removeObject(whiteboardObject: WhiteboardObject) async -> Bool {
-        let isContains = await whiteboardObjectSet.contains(object: whiteboardObject)
-        guard isContains else { return false }
+        guard await whiteboardObjectSet.contains(object: whiteboardObject) else { return false }
 
         await whiteboardObjectRepository.send(whiteboardObject: whiteboardObject, isDeleted: true)
         await whiteboardObjectSet.remove(object: whiteboardObject)

--- a/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
+++ b/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
@@ -372,7 +372,7 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
 
         // 검증
         XCTAssertTrue(isFailure)
-        XCTAssertEqual(targetObject.scale, 0)
+        XCTAssertEqual(targetObject.angle, 0)
     }
 
     // TODO: - 객체 수신, 삭제 테스트 코드 추가

--- a/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
+++ b/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
@@ -248,11 +248,15 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
             id: UUID(),
             centerPosition: .zero,
             size: CGSize(width: 100, height: 100),
+            scale: 1,
             selectedBy: myProfile)
 
         // 실행
         await useCase.addObject(whiteboardObject: targetObject)
-        let isSuccess = await useCase.changeSize(whiteboardObjectID: targetObject.id, to: 2)
+        let isSuccess = await useCase.changeSizeAndAngle(
+            whiteboardObjectID: targetObject.id,
+            scale: 2,
+            angle: targetObject.angle)
 
         // 검증
         XCTAssertTrue(isSuccess)
@@ -267,11 +271,15 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
             id: UUID(),
             centerPosition: .zero,
             size: CGSize(width: 100, height: 100),
+            scale: 1,
             selectedBy: strangerProfile)
 
         // 실행
         await useCase.addObject(whiteboardObject: targetObject)
-        let isFailure = await !useCase.changeSize(whiteboardObjectID: targetObject.id, to: 2)
+        let isFailure = await !useCase.changeSizeAndAngle(
+            whiteboardObjectID: targetObject.id,
+            scale: 2,
+            angle: targetObject.angle)
 
         // 검증
         XCTAssertTrue(isFailure)
@@ -285,16 +293,88 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
             id: UUID(),
             centerPosition: .zero,
             size: CGSize(width: 100, height: 100),
+            scale: 1,
             selectedBy: nil)
 
         // 실행
         await useCase.addObject(whiteboardObject: targetObject)
-        let isFailure = await !useCase.changeSize(whiteboardObjectID: targetObject.id, to: 2)
+        let isFailure = await !useCase.changeSizeAndAngle(
+            whiteboardObjectID: targetObject.id,
+            scale: 2,
+            angle: targetObject.angle)
 
         // 검증
         XCTAssertTrue(isFailure)
         XCTAssertEqual(targetObject.scale, 1)
     }
+
+    // 오브젝트 angle 변경 성공하는지 테스트
+    func testChangeAngleSuccess() async {
+        // 준비
+        let targetObject = WhiteboardObject(
+            id: UUID(),
+            centerPosition: .zero,
+            size: CGSize(width: 100, height: 100),
+            angle: 0,
+            selectedBy: myProfile)
+
+        // 실행
+        await useCase.addObject(whiteboardObject: targetObject)
+        let isSuccess = await useCase.changeSizeAndAngle(
+            whiteboardObjectID: targetObject.id,
+            scale: targetObject.scale,
+            angle: 1)
+
+        // 검증
+        XCTAssertTrue(isSuccess)
+        XCTAssertEqual(targetObject.angle, 1)
+    }
+
+    // 다른 사람이 선택 중일 때 angle 변경 실패하는지 테스트
+    func testChangeAngleFailsWhenSelectedByOther() async {
+        // 준비
+        let strangerProfile = Profile(nickname: "Other", profileIcon: .cold)
+        let targetObject = WhiteboardObject(
+            id: UUID(),
+            centerPosition: .zero,
+            size: CGSize(width: 100, height: 100),
+            angle: 0,
+            selectedBy: strangerProfile)
+
+        // 실행
+        await useCase.addObject(whiteboardObject: targetObject)
+        let isFailure = await !useCase.changeSizeAndAngle(
+            whiteboardObjectID: targetObject.id,
+            scale: targetObject.scale,
+            angle: 1)
+
+        // 검증
+        XCTAssertTrue(isFailure)
+        XCTAssertEqual(targetObject.angle, 0)
+    }
+
+    // 선택하지 않은 상태라 angle 변경 실패하는지 테스트
+    func testChangeAngleFailsWhenNotSelected() async {
+        // 준비
+        let targetObject = WhiteboardObject(
+            id: UUID(),
+            centerPosition: .zero,
+            size: CGSize(width: 100, height: 100),
+            angle: 0,
+            selectedBy: nil)
+
+        // 실행
+        await useCase.addObject(whiteboardObject: targetObject)
+        let isFailure = await !useCase.changeSizeAndAngle(
+            whiteboardObjectID: targetObject.id,
+            scale: targetObject.scale,
+            angle: 1)
+
+        // 검증
+        XCTAssertTrue(isFailure)
+        XCTAssertEqual(targetObject.scale, 0)
+    }
+
     // TODO: - 객체 수신, 삭제 테스트 코드 추가
 }
 

--- a/Presentation/Presentation/Sources/Profile/View/ProfileIconView.swift
+++ b/Presentation/Presentation/Sources/Profile/View/ProfileIconView.swift
@@ -38,4 +38,8 @@ final class ProfileIconView: UIView {
         backgroundColor = UIColor(hex: profileIcon.colorHex)
         layer.cornerRadius = profileIconSize / 2
     }
+
+    func rotate(angle: CGFloat) {
+        iconLabel.transform = CGAffineTransform(rotationAngle: angle)
+    }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -150,10 +150,6 @@ public final class WhiteboardViewController: UIViewController {
         canvasView.addSubview(objectView)
     }
 
-    private func addText() {
-        viewModel.action(input: .addTextObject(point: visibleCenterPoint, viewSize: view.frame.size))
-    }
-
     // TODO: 이후에 Done 버튼이 생길경우 사용할 메소드
     private func endEditObject() {
         view.endEditing(true)
@@ -170,12 +166,12 @@ public final class WhiteboardViewController: UIViewController {
         viewModel.action(input: .finishUsingTool)
     }
 
-    @objc private func handleScrollViewTapGesture(_ gesture: UITapGestureRecognizer) {
+    @objc private func handleScrollViewTapGesture(gesture: UITapGestureRecognizer) {
         let location = gesture.location(in: canvasView)
         let touchedView = canvasView.hitTest(location, with: nil)
 
         if let touchedView = touchedView as? WhiteboardObjectView {
-            viewModel.action(input: .selectObject(objectID: touchedView.objectId))
+            viewModel.action(input: .selectObject(objectID: touchedView.objectID))
         } else {
             viewModel.action(input: .deselectObject)
         }
@@ -186,7 +182,9 @@ public final class WhiteboardViewController: UIViewController {
 extension WhiteboardViewController: WhiteboardToolBarDelegate {
     func whiteboardToolBar(_ sender: WhiteboardToolBar, selectedTool: WhiteboardTool) {
         viewModel.action(input: .selectTool(tool: selectedTool))
-        if selectedTool == .text { addText() }
+        if selectedTool == .text {
+            viewModel.action(input: .addTextObject(point: visibleCenterPoint, viewSize: view.frame.size))
+        }
     }
 }
 
@@ -231,16 +229,24 @@ extension WhiteboardViewController: PHPickerViewControllerDelegate {
 }
 
 extension WhiteboardViewController: WhiteboardObjectViewDelegate {
-    public func whiteboardObjectViewDidEndPanning(
+    public func whiteboardObjectViewDidEndScaling(
         _ sender: WhiteboardObjectView,
         objectID: UUID,
-        scale: CGFloat
+        scale: CGFloat,
+        angle: CGFloat
     ) {
-        viewModel.action(input: .changeObjectScale(objectID: objectID, scale: scale))
-        scrollView.isScrollEnabled = true
+        viewModel.action(
+            input: .changeObjectScaleAndAngle(
+                objectID: objectID,
+                scale: scale,
+                angle: angle))
     }
 
-    public func whiteboardObjectViewDidStartPanning(_ sender: WhiteboardObjectView) {
-        scrollView.isScrollEnabled = false
+    public func whiteboardObjectViewDidEndMoving(
+        _ sender: WhiteboardObjectView,
+        objectID: UUID,
+        newCenter: CGPoint
+    ) {
+        viewModel.action(input: .changeObjectPosition(objectID: objectID, point: newCenter))
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -22,7 +22,10 @@ public final class WhiteboardViewModel: ViewModel {
         case addTextObject(point: CGPoint, viewSize: CGSize)
         case selectObject(objectID: UUID)
         case deselectObject
-        case changeObjectScale(objectID: UUID, scale: CGFloat)
+        case changeObjectScaleAndAngle(
+            objectID: UUID,
+            scale: CGFloat,
+            angle: CGFloat)
         case changeObjectPosition(objectID: UUID, point: CGPoint)
     }
 
@@ -91,8 +94,8 @@ public final class WhiteboardViewModel: ViewModel {
             selectObject(objectID: objectID)
         case .deselectObject:
             deselectObject()
-        case .changeObjectScale(let objectID, let scale):
-            changeObjectScale(objectID: objectID, to: scale)
+        case .changeObjectScaleAndAngle(let objectID, let scale, let angle):
+            changeObjectScale(objectID: objectID, scale: scale, angle: angle)
         case .changeObjectPosition(let objectID, let position):
             changeObjectPosition(objectID: objectID, to: position)
         }
@@ -180,9 +183,16 @@ public final class WhiteboardViewModel: ViewModel {
         }
     }
 
-    private func changeObjectScale(objectID: UUID, to scale: CGFloat) {
+    private func changeObjectScale(
+        objectID: UUID,
+        scale: CGFloat,
+        angle: CGFloat
+    ) {
         Task {
-            await manageWhiteboardObjectUseCase.changeSize(whiteboardObjectID: objectID, to: scale)
+            await manageWhiteboardObjectUseCase.changeSizeAndAngle(
+                whiteboardObjectID: objectID,
+                scale: scale,
+                angle: angle)
         }
     }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 화이트보드 오브젝트 위치 수정, 각도 수정 기능 구현

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- iPhone SE3

https://github.com/user-attachments/assets/b16693ab-4b2a-4bf3-8e37-6636c4c82d5e


- iPhone 13 mini 

https://github.com/user-attachments/assets/5f88c713-b9e2-4a2b-816b-a79c3c6c5544


- iPhone 16 Pro 

https://github.com/user-attachments/assets/30cee61b-1a0f-43a3-a15d-0734f75b4f05



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 오브젝트 이동
- 오브젝트 view에 pangesture를 추가하여, 드래그 이후 새로운 center를 vc에게 delegate로 전달합니다. vc에서는 해당 좌표를 viewModel을 통해 usecase에게 전달합니다

### 오브젝트 각도 조절
- 삼각함수를 너무 오랜만에 봐서,, 관련 내용을 완벽 숙지하지는 못했지만 각도 계산을 위해 atan (아크 탄젠트)를 사용할 수 있다는 것을 알았습니다.
- atan은 두 점 사이의 탄젠트 값(실수)를 받아서 -π/2 ~ π/2의 라디안 값으로 반환합니다. (아시다시피 π는 180도 입니다!)
- atan2는 원점(0,0)부터 좌표 (x, y)까지의 선과 x축이 이루는 각도를 라디안 값으로 반환합니다.
- atan2는 두 점 사이의 상대좌표를 받아 -π ~ π 의 라디안 값으로 반환할 수 있어 모든 사분면을 표시할 수 있다고 합니다! 따라서 atan2를 사용하기로 했습니다
- 처음 각도를 계산할 때 아무런 회전을 하지 않아도, controlView(우측 하단의 화살표 뷰)와 x축 사이의 각도가 있기 때문에 초록색 만큼의 각을 빼주고 시작해야 합니다.
![스크린샷 2024-11-25 오전 10 03 37](https://github.com/user-attachments/assets/0bcf9c7a-04d2-4976-84b7-8439c3f15fc1)

- 추가로 어떤 도형은 이미 회전이 되어 있는 상태에서 추가로 회전을 해야하는 경우가 있을 수 있습니다. 이런 경우에는 회전한 각도에 이전에 이미 회전한 각도를 더해줘야 합니다.
![스크린샷 2024-11-25 오전 10 39 29](https://github.com/user-attachments/assets/6f9a2306-7736-47ec-a34f-5d3fcd225545)



- 이미 회전한 각도는 transform의 b, a를 이용해서 구할 수 있는데요. transform행렬은 아래와 같이 생겼습니다.
![스크린샷 2024-11-25 오전 10 54 54](https://github.com/user-attachments/assets/0c8a151d-6fb9-45f7-beec-746d64465ece)

- 아핀 행렬을 이용해 (x, y)을 변환하면, 저희가 원하는 새로운 (x’, y’)를 구할 수 있는 것인데요, 아핀 변환 행렬은 아래와 같습니다.
![스크린샷 2024-11-25 오전 10 49 00](https://github.com/user-attachments/assets/124c7032-4bbe-4a11-985a-5541b8c6f838)

- 현재 회전 각도가 필요하기 때문에, transform의 a와 b를 이용해서 cos값과 sin값을 알 수 있습니다. 이전에 배웠던 수학지식을 열심히 열심히 더듬어보면, 단위원에서 cos값은 x좌표를, sin값은 y좌표를 나타냅니다. 따라서 위에서 다른 각도를 계산한 것처럼 atan2(transform.b, transform.a)를 이용해 현재 오브젝트의 회전한 각도를 알 수 있습니다
- 완벽하게 모든 것을 이해하지는 못했지만, CGAffineTransform에 대해 나중에 같이 정리하는 것도 좋을 것 같습니다~!

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 코드 실행

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
**지나치게 똑똑해진 ObjectView**
- ObjectView에서 너무 많은 로직을 수행하고 있다고 느껴졌습니다..
- 더 나은 구조, 더 멍청한 view를 이후 리팩토링 기간 동안 고민하고 수정하면 좋을 것 같습니다.

**수정 가능 로직이 잘못된 문제**
- 현재 오브젝트를 선택한 사람이 있다면, 본인이 선택하지 않았어도 objectView의 pangesture들을 사용할 수 있는 문제가 있습니다. 
- 다음 PR에서 수정하도록 하겠습니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #34 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
**아크 탄젠트**
https://ko.khanacademy.org/math/geometry/hs-geo-trig/hs-geo-solve-for-an-angle/a/inverse-trig-functions-intro
https://blog.spiralmoon.dev/entry/%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%B0%8D-%EC%9D%B4%EB%A1%A0-%EB%91%90-%EC%A0%90-%EC%82%AC%EC%9D%B4%EC%9D%98-%EC%A0%88%EB%8C%80%EA%B0%81%EB%8F%84%EB%A5%BC-%EC%9E%AC%EB%8A%94-atan2
https://support.microsoft.com/ko-kr/office/atan2-%ED%95%A8%EC%88%98-c04592ab-b9e3-4908-b428-c96b3a565033

**아핀 변환**
https://kr.mathworks.com/discovery/affine-transformation.html
https://hansolkkim.github.io/posts/CGAffineTransform/

