### PR TITLE
[Feature] 오브젝트 삭제 기능 추가, 수정 로직 수정

### DIFF
--- a/AirplaIN/AirplaIN/Assets.xcassets/AirplainBlack.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/AirplainBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/AirplainBlue.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/AirplainBlue.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0x95",
+          "red" : "0x64"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/AirplainWhite.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/AirplainWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x13",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray100.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF6",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray200.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF0",
+          "green" : "0xEB",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray300.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE2",
+          "green" : "0xDC",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray400.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD4",
+          "green" : "0xCA",
+          "red" : "0xC4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray500.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray500.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBD",
+          "green" : "0xAD",
+          "red" : "0xA5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray600.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA3",
+          "green" : "0x95",
+          "red" : "0x8E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray700.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6C",
+          "green" : "0x61",
+          "red" : "0x5B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray800.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x49",
+          "green" : "0x3C",
+          "red" : "0x35"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/Gray900.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/Gray900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x27",
+          "green" : "0x1E",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/WordleRed.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/WordleRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4D",
+          "green" : "0x4D",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AirplaIN/AirplaIN/Assets.xcassets/WordleYellow.colorset/Contents.json
+++ b/AirplaIN/AirplaIN/Assets.xcassets/WordleYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x40",
+          "green" : "0xD6",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
@@ -34,9 +34,9 @@ public protocol ManageWhiteboardObjectUseCaseInterface {
     func updateObject(whiteboardObject: WhiteboardObject) async -> Bool
 
     /// 화이트보드를 제거하는 메서드
-    /// - Returns: 추가 성공 여부
+    /// - Returns: 제거 성공 여부
     @discardableResult
-    func removeObject(whiteboardObject: WhiteboardObject) async -> Bool
+    func removeObject(whiteboardObjectID: UUID) async -> Bool
 
     /// 화이트보드 오브젝트를 선택합니다.
     /// - Parameter whiteboardObject: 선택할 오브젝트

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -20,6 +20,6 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
             id: UUID(),
             centerPosition: point,
             size: textFieldDefaultSize,
-            text: "")
+            text: "Hello, AirplaIN!")
     }
 }

--- a/Presentation/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation/Presentation.xcodeproj/project.pbxproj
@@ -99,7 +99,6 @@
 			isa = PBXGroup;
 			children = (
 				0080E8C52CE2F04F0095B958 /* WhiteboardObjectView.swift */,
-				6F199EF02CE31A05005DC40F /* WhiteboardToolBar.swift */,
 				6F21477C2CE4EFCF00B55E2C /* TextObjectView.swift */,
 				00D2DD992CE8DCEA0089F0BA /* DrawingObjectView.swift */,
 				004B21802CEB5BC000A5BEB8 /* PhotoObjectView.swift */,
@@ -151,6 +150,7 @@
 			children = (
 				6F199EF22CE3203A005DC40F /* WhiteboardViewController.swift */,
 				00D2DD972CE8CD300089F0BA /* DrawingView.swift */,
+				6F199EF02CE31A05005DC40F /* WhiteboardToolBar.swift */,
 				004645F22CE60A1B00C76EDB /* ObjectView */,
 			);
 			path = View;

--- a/Presentation/Presentation/Sources/Whiteboard/Util/DrawingRenderer.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Util/DrawingRenderer.swift
@@ -28,6 +28,6 @@ struct DrawingRenderer: DrawingRendererInterface {
 
             context.cgContext.strokePath()
         }
-        return image
+        return image.withRenderingMode(.alwaysTemplate)
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/DrawingObjectView.swift
@@ -9,7 +9,11 @@ import Domain
 import UIKit
 
 final class DrawingObjectView: WhiteboardObjectView {
-    let imageView = UIImageView()
+    let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = .airplainBlack
+        return imageView
+    }()
 
     init(drawingObject: DrawingObject) {
         super.init(whiteboardObject: drawingObject)
@@ -32,6 +36,7 @@ final class DrawingObjectView: WhiteboardObjectView {
     private func renderImage(with object: DrawingObject) {
         let renderer = DrawingRenderer()
         let renderedImage = renderer.render(drawingObject: object)
+
         imageView.image = renderedImage
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -43,7 +43,7 @@ final class TextObjectView: WhiteboardObjectView {
     override func update(with object: WhiteboardObject) {
         super.update(with: object)
         guard let textObject = object as? TextObject else { return }
-        print(textObject.text)
+
         textView.text = textObject.text
     }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -9,11 +9,14 @@ import Domain
 import UIKit
 
 final class TextObjectView: WhiteboardObjectView {
-    private let textField: UITextField = {
-        let textField = UITextField()
-        textField.textAlignment = .center
-        textField.placeholder = "Hello AirplaIN"
-        return textField
+    private let textView: UITextView = {
+        let textView = UITextView()
+        textView.textAlignment = .center
+        textView.textColor = .airplainBlack
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.isUserInteractionEnabled = false
+        return textView
     }()
 
     init(textObject: TextObject) {
@@ -26,17 +29,12 @@ final class TextObjectView: WhiteboardObjectView {
         super.init(coder: coder)
     }
 
-    override func becomeFirstResponder() -> Bool {
-        textField.becomeFirstResponder()
-    }
-
     private func configureAttribute() {
-        textField.delegate = self
-        textField.backgroundColor = .clear
+        textView.delegate = self
     }
 
     override func configureLayout() {
-        textField
+        textView
             .addToSuperview(self)
             .edges(equalTo: self)
         super.configureLayout()
@@ -45,23 +43,34 @@ final class TextObjectView: WhiteboardObjectView {
     override func update(with object: WhiteboardObject) {
         super.update(with: object)
         guard let textObject = object as? TextObject else { return }
-        textField.text = textObject.text
+        print(textObject.text)
+        textView.text = textObject.text
+    }
+
+    override func configureEditable(isEditable: Bool) {
+        super.configureEditable(isEditable: isEditable)
+        textView.isUserInteractionEnabled = isEditable
     }
 }
 
-extension TextObjectView: UITextFieldDelegate {
-    func textField(
-        _ textField: UITextField,
-        shouldChangeCharactersIn range: NSRange,
-        replacementString string: String
+extension TextObjectView: UITextViewDelegate {
+    func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
     ) -> Bool {
+        guard text != "\n" else {
+            textView.resignFirstResponder()
+            return false
+        }
+
         let maxLength = 15
-        guard let text = textField.text else { return true }
-        let newlength = text.count + string.count - range.length
+        guard let originText = textView.text else { return true }
+        let newlength = originText.count + text.count - range.length
         return newlength < maxLength
     }
 
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
+    func textViewDidEndEditing(_ textView: UITextView) {
+        // TODO: - TextView 수정 로직 추가
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardObjectView.swift
@@ -10,13 +10,9 @@ import UIKit
 public protocol WhiteboardObjectViewDelegate: AnyObject {
     func whiteboardObjectViewDidEndScaling(
         _ sender: WhiteboardObjectView,
-        objectID: UUID,
         scale: CGFloat,
         angle: CGFloat)
-    func whiteboardObjectViewDidEndMoving(
-        _ sender: WhiteboardObjectView,
-        objectID: UUID,
-        newCenter: CGPoint)
+    func whiteboardObjectViewDidEndMoving(_ sender: WhiteboardObjectView, newCenter: CGPoint)
 }
 
 public class WhiteboardObjectView: UIView {
@@ -69,6 +65,7 @@ public class WhiteboardObjectView: UIView {
         configureAttribute()
         configureLayout()
         update(with: whiteboardObject)
+        configureEditable(isEditable: false)
     }
 
     required init?(coder: NSCoder) {
@@ -77,6 +74,7 @@ public class WhiteboardObjectView: UIView {
         super.init(coder: coder)
         configureAttribute()
         configureLayout()
+        configureEditable(isEditable: false)
     }
 
     override public func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
@@ -124,6 +122,11 @@ public class WhiteboardObjectView: UIView {
                 inset: WhiteboardObjectViewLayoutConstant.controlViewInset)
     }
 
+    func configureEditable(isEditable: Bool) {
+        controlView.isHidden = !isEditable
+        gestureRecognizers?.forEach { $0.isEnabled = isEditable }
+    }
+
     func select(selector: Profile) {
         CATransaction.setAnimationDuration(0)
 
@@ -139,15 +142,12 @@ public class WhiteboardObjectView: UIView {
         controlView.isHidden = false
         borderLayer.frame = calculateBorderFrame()
         borderLayer.borderColor = profileColor.cgColor
-        gestureRecognizers?.forEach { $0.isEnabled = true }
     }
 
     func deselect() {
         CATransaction.setAnimationDuration(0)
         borderLayer.removeFromSuperlayer()
         profileIconView.isHidden = true
-        controlView.isHidden = true
-        gestureRecognizers?.forEach { $0.isEnabled = false }
     }
 
     func update(with object: WhiteboardObject) {
@@ -194,7 +194,6 @@ public class WhiteboardObjectView: UIView {
             angle = lockAngle(angle: angle)
             delegate?.whiteboardObjectViewDidEndScaling(
                 self,
-                objectID: objectID,
                 scale: scale,
                 angle: angle)
             initialControlAngle = nil
@@ -271,10 +270,7 @@ public class WhiteboardObjectView: UIView {
         case .changed:
             center = newCenter
         default:
-            delegate?.whiteboardObjectViewDidEndMoving(
-                self,
-                objectID: objectID,
-                newCenter: newCenter)
+            delegate?.whiteboardObjectViewDidEndMoving(self, newCenter: newCenter)
         }
 
         gesture.setTranslation(.zero, in: superview)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->


## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- iPhone SE3

https://github.com/user-attachments/assets/b13615f3-0ac3-4760-93bd-6b4bb647fedb

- iPhone 13 mini

https://github.com/user-attachments/assets/68d49eba-2ffd-494b-98ae-07a1092d2646

- iPhone 16 Pro

https://github.com/user-attachments/assets/dece6f81-6ff7-4150-93c0-b21979a647d3



## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
### 오브젝트 삭제 기능 추가
- Freeform을 참고하여 오브젝트 선택 시 `toolBar`에 삭제 버튼이 표시되도록 했습니다.
### 오브젝트 수정 로직 수정
- 오브젝트에 `selectedBy`가 `nil`이 아니면, 누구든지 오브젝트를 수정할 수 있는 문제가 있었습니다.
- WhiteboardObjectView에 `configureIsEditable`이라는 메서드를 두고, 이를 통해 수정 gesture를 할수 있는지 없는지 설정할 수 있게 했습니다.
### 잡다한 기능
- 이제 다크 모드에서 그린 그림이 흰색으로 표시됩니다.
- TextViewObject의 TextField가 TextView로 변경되었습니다. (기간 내 구현은 힘들겠지만, text 여러 줄 표시를 위해서)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 테스트 코드 실행


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 빠른 작업을 위해 규모가 작은 여러 작업을 하나의 pr에 모아 진행했습니다.
- 다음 PR에서는 TextView 수정로직 구현, PhotoUseCase에서 직접 사용하는 영속성 관련 객체 삭제 작업을 진행할 예정입니다.

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #38
- close #31 
- close #34 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
