### PR TITLE
[Feature] WhiteboardList 당겨서 새로고침 구현 및 다크모드 대응

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -17,6 +17,9 @@ public protocol NearbyNetworkInterface {
     /// 주변 기기 검색을 중지합니다.
     func stopSearching()
 
+    /// 주변 기기 검색을 중지 후 다시 시작합니다. 
+    func restartSearching()
+
     /// 주변에 내 기기를 정보와 함께 알립니다.
     /// - Parameter data: 담을 정보
     func startPublishing(with info: [String: String])

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -55,6 +55,10 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         nearbyNetwork.stopSearching()
     }
 
+    public func restartSearching() {
+        nearbyNetwork.restartSearching()
+    }
+
     private func updatePublishingInfo(myProfile: Profile) {
         var newIconList: [String] = []
         newIconList.append(myProfile.profileIcon.emoji)

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -18,6 +18,9 @@ public protocol WhiteboardRepositoryInterface {
 
     /// 화이트보드 탐색을 중지합니다.
     func stopSearching()
+    
+    /// 화이트보드 탐색을 중단 후 다시 시작합니다. 
+    func restartSearching()
 
     /// 선택한 화이트보드와 연결을 시도합니다.
     /// - Parameter whiteboard: 연결할 화이트보드

--- a/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
@@ -25,4 +25,7 @@ public protocol WhiteboardUseCaseInterface {
 
     /// 화이트보드 탐색을 중지합니다.
     func stopSearchingWhiteboard()
+    
+    /// 화이트보드 탐색을 중단 후 다시 시작합니다. 
+    func refreshWhiteboardList()
 }

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -50,6 +50,10 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
         let profile = profileRepository.loadProfile()
         try whiteboardRepository.joinWhiteboard(whiteboard: whiteboard, myProfile: profile)
     }
+
+    public func refreshWhiteboardList() {
+        whiteboardRepository.restartSearching()
+    }
 }
 
 extension WhiteboardUseCase: WhiteboardRepositoryDelegate {

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -53,6 +53,14 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         serviceBrowser.stopBrowsingForPeers()
     }
 
+    public func restartSearching() {
+        serialQueue.sync {
+            serviceBrowser.stopBrowsingForPeers()
+            foundPeers.removeAll()
+            serviceBrowser.startBrowsingForPeers()
+        }
+    }
+
     public func startPublishing(with info: [String: String]) {
         isHost = true
         serviceAdvertiser.stopAdvertisingPeer()

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardCell.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardCell.swift
@@ -28,7 +28,9 @@ class WhiteboardCell: UICollectionViewCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = AirplainFont.Subtitle2
-        label.textColor = .black
+        let originColor = UIColor(named: "AirplainBlack") ?? .black
+        let resolvedColor = originColor.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        label.textColor = resolvedColor
         return label
     }()
 

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardCell.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardCell.swift
@@ -28,7 +28,7 @@ class WhiteboardCell: UICollectionViewCell {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = AirplainFont.Subtitle2
-        label.textColor = .airplainBlack
+        label.textColor = .black
         return label
     }()
 

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -246,13 +246,6 @@ public final class WhiteboardListViewController: UIViewController {
     }
 
     private func bind() {
-        viewModel.output.whiteboardPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { _ in
-                // TODO: 화이트보드 추가
-            }
-            .store(in: &cancellables)
-
         viewModel.output.whiteboardListPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] whiteboards in

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -56,6 +56,7 @@ public final class WhiteboardListViewController: UIViewController {
     }()
 
     private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    private let refreshControl = UIRefreshControl()
     private var dataSource: UICollectionViewDiffableDataSource<Int, Whiteboard>?
     private let viewModel: WhiteboardListViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -171,8 +172,14 @@ public final class WhiteboardListViewController: UIViewController {
     private func configureCollectionView() {
         collectionView.delegate = self
         collectionView.collectionViewLayout = createCollectionViewLayout()
-        collectionView.backgroundColor = .white
+        collectionView.backgroundColor = .systemBackground
         collectionView.register(WhiteboardCell.self, forCellWithReuseIdentifier: WhiteboardCell.reuseIdentifier)
+
+        let refreshAction = UIAction { [weak self] _ in
+            self?.refreshWhiteboardList()
+        }
+        refreshControl.addAction(refreshAction, for: .valueChanged)
+        collectionView.refreshControl = refreshControl
     }
 
     private func createCollectionViewLayout() -> UICollectionViewLayout {
@@ -237,6 +244,7 @@ public final class WhiteboardListViewController: UIViewController {
         guard let dataSource = dataSource else { return }
         dataSource.apply(snapshot, animatingDifferences: true)
     }
+
     private func bind() {
         viewModel.output.whiteboardPublisher
             .receive(on: DispatchQueue.main)
@@ -252,6 +260,13 @@ public final class WhiteboardListViewController: UIViewController {
                 self?.applySnapshot(whiteboards: whiteboards)
             }
             .store(in: &cancellables)
+    }
+
+    private func refreshWhiteboardList() {
+        viewModel.action(input: .refreshWhiteboardList)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.refreshControl.endRefreshing()
+        }
     }
 }
 

--- a/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
@@ -18,6 +18,7 @@ public final class WhiteboardListViewModel: ViewModel {
         case searchWhiteboard
         case joinWhiteboard(whiteboard: Whiteboard)
         case stopSearchingWhiteboard
+        case refreshWhiteboardList
     }
 
     struct Output {
@@ -46,6 +47,8 @@ public final class WhiteboardListViewModel: ViewModel {
             joinWhiteboard(whiteboard: whiteboard)
         case .stopSearchingWhiteboard:
             stopSearchingWhiteboard()
+        case .refreshWhiteboardList:
+            refreshWhiteboardList()
         }
     }
 
@@ -69,5 +72,9 @@ public final class WhiteboardListViewModel: ViewModel {
 
     private func stopSearchingWhiteboard() {
         whiteboardUseCase.stopSearchingWhiteboard()
+    }
+
+    private func refreshWhiteboardList() {
+        whiteboardUseCase.refreshWhiteboardList()
     }
 }

--- a/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
@@ -22,7 +22,6 @@ public final class WhiteboardListViewModel: ViewModel {
     }
 
     struct Output {
-        let whiteboardPublisher: AnyPublisher<Whiteboard, Never>
         let whiteboardListPublisher: AnyPublisher<[Whiteboard], Never>
     }
 
@@ -33,7 +32,6 @@ public final class WhiteboardListViewModel: ViewModel {
         self.whiteboardUseCase = whiteboardUseCase
         whiteboardSubject = PassthroughSubject<Whiteboard, Never>()
         self.output = Output(
-            whiteboardPublisher: whiteboardSubject.eraseToAnyPublisher(),
             whiteboardListPublisher: whiteboardUseCase.whiteboardListPublisher)
     }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 기존 서칭 로직으로의 복귀로 인해 부득이하게 당겨서 새로고침 기능을 추가했습니다. 
- 컬렉션뷰 및 컬렉션뷰 셀 다크모드 대응을 추가했습니다. 

## 📱 Screenshot
- 각 시뮬레이터간의 연관성으로 인해 하나의 영상으로 대체합니다. 
- 왼쪽부터 실 기기, 16 Pro, SE3, 13 mini 입니다. 

https://github.com/user-attachments/assets/e5067598-ed31-4aa3-81e3-889382184f53

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 당겨서 새로고침 구현
    - 로직은 Searching 정지, 기존 foundPeers 삭제 후 다시 Searching하는 방식입니다. 
    - 삭제하지 않으면 `serviceBrowser`가 꺼졌을 때 사라진 피어를 찾지 못하기 때문입니다. 
- 컬렉션뷰와 컬렉션뷰 셀의 다크모드 대응

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #11
- close #14 