### PR TITLE
[Feature] 사진 오브젝트 전송 로직 수정, Text 오브젝트 수정 기능 추가

### DIFF
--- a/AirplaIN/AirplaIN/SceneDelegate.swift
+++ b/AirplaIN/AirplaIN/SceneDelegate.swift
@@ -24,15 +24,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // TODO: - 임시 의존성 주입
         let nearbyNetworkService = NearbyNetworkService(serviceName: "airplain")
-        let profileRepository = ProfileRepository(persistenceService: PersistenceService())
         let filePersistenceService = FilePersistence()
+        let whiteboardObjectSet = WhiteboardObjectSet()
 
+        let profileRepository = ProfileRepository(persistenceService: PersistenceService())
         let whiteboardRepository = WhiteboardRepository(
             nearbyNetworkInterface: nearbyNetworkService,
             myProfile: profileRepository.loadProfile())
         let whiteboardObjectRepository = WhiteboardObjectRepository(
             nearbyNetwork: nearbyNetworkService,
             filePersistence: filePersistenceService)
+        let photoRepository = PhotoRepository(filePersistence: filePersistenceService)
 
         let whiteboardUseCase = WhiteboardUseCase(
             whiteboardRepository: whiteboardRepository,
@@ -40,11 +42,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let profileUseCase = ProfileUseCase(repository: profileRepository)
         let manageWhieboardObjectUseCase = ManageWhiteboardObjectUseCase(
             profileRepository: profileRepository,
-            whiteboardRepository: whiteboardObjectRepository)
+            whiteboardRepository: whiteboardObjectRepository,
+            whiteboardObjectSet: whiteboardObjectSet)
         let manageWhiteboardToolUseCase = ManageWhiteboardToolUseCase()
-        let textObjectUseCase = TextObjectUseCase(textFieldDefaultSize: CGSize(width: 200, height: 50))
+        let textObjectUseCase = TextObjectUseCase(
+            whiteboardObjectSet: whiteboardObjectSet,
+            textFieldDefaultSize: CGSize(width: 200, height: 50))
         let drawObjectUseCase = DrawObjectUseCase()
-        guard let addPhotoUseCase = try? AddPhotoUseCase() else { return }
+        let addPhotoUseCase = AddPhotoUseCase(photoRepository: photoRepository)
         let whiteboardObjectSendUseCase = WhiteboardObjectSendUseCase(repository: whiteboardObjectRepository)
 
         let whiteboardObjectViewFactory = WhiteboardObjectViewFactory()

--- a/DataSource/DataSource.xcodeproj/project.pbxproj
+++ b/DataSource/DataSource.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00036B842CF5648A007D1244 /* PhotoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00036B832CF5648A007D1244 /* PhotoRepository.swift */; };
 		00549AD02CEDBAAD00DF8F6C /* AirplaINDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549ACF2CEDBA5E00DF8F6C /* AirplaINDataType.swift */; };
 		00549AD22CEDBB3E00DF8F6C /* DataInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD12CEDBB0E00DF8F6C /* DataInformationDTO.swift */; };
 		0080E8652CE19EC40095B958 /* NearbyNetworkInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E85F2CE19EC40095B958 /* NearbyNetworkInterface.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00036B832CF5648A007D1244 /* PhotoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepository.swift; sourceTree = "<group>"; };
 		00549ACF2CEDBA5E00DF8F6C /* AirplaINDataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirplaINDataType.swift; sourceTree = "<group>"; };
 		00549AD12CEDBB0E00DF8F6C /* DataInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataInformationDTO.swift; sourceTree = "<group>"; };
 		0080E85F2CE19EC40095B958 /* NearbyNetworkInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkInterface.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				A852601D2CE339E70089DA5E /* ProfileRepository.swift */,
 				5BDFD93C2CE2F56B00DA4F5B /* WhiteboardRepository.swift */,
 				6FF51C782CEF07D2005DE9CD /* WhiteboardObjectRepository.swift */,
+				00036B832CF5648A007D1244 /* PhotoRepository.swift */,
 				6F3BCDCB2CF31F5C005F6642 /* ChatRepository.swift */,
 			);
 			path = Repository;
@@ -250,6 +253,7 @@
 				0080E8652CE19EC40095B958 /* NearbyNetworkInterface.swift in Sources */,
 				5BDFD93D2CE2F56B00DA4F5B /* WhiteboardRepository.swift in Sources */,
 				0080E8662CE19EC40095B958 /* NetworkConnection.swift in Sources */,
+				00036B842CF5648A007D1244 /* PhotoRepository.swift in Sources */,
 				A852601E2CE339E70089DA5E /* ProfileRepository.swift in Sources */,
 				6FF51C792CEF07D2005DE9CD /* WhiteboardObjectRepository.swift in Sources */,
 				00549AD22CEDBB3E00DF8F6C /* DataInformationDTO.swift in Sources */,

--- a/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
@@ -14,7 +14,10 @@ public protocol FilePersistenceInterface {
     ///   - data: 저장할 데이터
     /// - Returns: URL로 저장된 위치 반환
     @discardableResult
-    func save(dataInfo: DataInformationDTO, data: Data?) -> URL?
+    func save(
+        dataInfo: DataInformationDTO,
+        data: Data?,
+        fileType: String?) -> URL?
 
     /// path위치에 있는 데이터를 가져옵니다.
     /// - Parameter path: 가져올 데이터의 위치를 URL로 받습니다.

--- a/DataSource/DataSource/Sources/Model/AirplaINDataType.swift
+++ b/DataSource/DataSource/Sources/Model/AirplaINDataType.swift
@@ -12,5 +12,5 @@ public enum AirplaINDataType: String, Codable {
     case drawing
     case game
     case chat
-    case jpg
+    case imageData
 }

--- a/DataSource/DataSource/Sources/Model/AirplaINDataType.swift
+++ b/DataSource/DataSource/Sources/Model/AirplaINDataType.swift
@@ -12,4 +12,5 @@ public enum AirplaINDataType: String, Codable {
     case drawing
     case game
     case chat
+    case jpg
 }

--- a/DataSource/DataSource/Sources/Repository/ChatRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/ChatRepository.swift
@@ -34,7 +34,10 @@ public final class ChatRepository: ChatRepositoryInterface {
             isDeleted: false)
         guard
             let url = filePersistence
-                .save(dataInfo: chatMessageInformation, data: chatMessageData)
+                .save(
+                    dataInfo: chatMessageInformation,
+                    data: chatMessageData,
+                    fileType: nil)
         else {
             logger.log(level: .error, "url저장 실패: 데이터를 보내지 못했습니다.")
             return nil
@@ -55,7 +58,10 @@ extension ChatRepository: NearbyNetworkReceiptDelegate {
         info: DataInformationDTO
     ) {
         guard let receivedData = filePersistence.load(path: URL) else { return }
-        filePersistence.save(dataInfo: info, data: receivedData)
+        filePersistence.save(
+            dataInfo: info,
+            data: receivedData,
+            fileType: nil)
         guard
             let chatMessage = try? JSONDecoder().decode(
                 ChatMessage.self,

--- a/DataSource/DataSource/Sources/Repository/PhotoRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/PhotoRepository.swift
@@ -1,0 +1,30 @@
+//
+//  PhotoRepository.swift
+//  DataSource
+//
+//  Created by 이동현 on 11/26/24.
+//
+
+import Domain
+import Foundation
+
+public final class PhotoRepository: PhotoRepositoryInterface {
+    private let filePersistence: FilePersistenceInterface
+
+    public init(filePersistence: FilePersistenceInterface) {
+        self.filePersistence = filePersistence
+    }
+
+    public func savePhoto(id: UUID, imageData: Data) -> URL? {
+        let dataInformation = DataInformationDTO(
+            id: id,
+            type: .jpg,
+            isDeleted: false)
+
+        let photoURL = filePersistence.save(
+            dataInfo: dataInformation,
+            data: imageData,
+            fileType: ".jpg")
+        return photoURL
+    }
+}

--- a/DataSource/DataSource/Sources/Repository/PhotoRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/PhotoRepository.swift
@@ -18,7 +18,7 @@ public final class PhotoRepository: PhotoRepositoryInterface {
     public func savePhoto(id: UUID, imageData: Data) -> URL? {
         let dataInformation = DataInformationDTO(
             id: id,
-            type: .jpg,
+            type: .imageData,
             isDeleted: false)
 
         let photoURL = filePersistence.save(

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -35,7 +35,7 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
         case let photoObject as PhotoObject:
             async let sendJPEGTask: () = sendJPEG(
                 photoObject: photoObject,
-                type: .jpg,
+                type: .imageData,
                 isDeleted: isDeleted)
             async let sendPhotoObjectTask: () = send(
                 whiteboardObject: photoObject,
@@ -75,7 +75,7 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
     ) async {
         let dataInformation = DataInformationDTO(
             id: photoObject.id,
-            type: .jpg,
+            type: .imageData,
             isDeleted: isDeleted)
         await nearbyNetwork.send(fileURL: photoObject.photoURL, info: dataInformation)
     }
@@ -91,7 +91,7 @@ extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
         didReceiveURL URL: URL,
         info: DataInformationDTO
     ) {
-        if info.type != .jpg {
+        if info.type != .imageData {
             handleWhiteboardObject(didReceiveURL: URL, info: info)
         } else {
             handlePhotoData(didReceiveURL: URL, info: info)

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -33,10 +33,16 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
                 type: .drawing,
                 isDeleted: isDeleted)
         case let photoObject as PhotoObject:
-            await send(
+            async let sendJPEGTask: () = sendJPEG(
+                photoObject: photoObject,
+                type: .jpg,
+                isDeleted: isDeleted)
+            async let sendPhotoObjectTask: () = send(
                 whiteboardObject: photoObject,
                 type: .photo,
                 isDeleted: isDeleted)
+            await sendJPEGTask
+            await sendPhotoObjectTask
         default:
             break
         }
@@ -53,12 +59,25 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
             type: type,
             isDeleted: isDeleted)
         guard let url = filePersistence
-            .save(dataInfo: objectInformation, data: objectData)
+            .save(dataInfo: objectInformation, data: objectData, fileType: nil)
         else {
             logger.log(level: .error, "url저장 실패: 데이터를 보내지 못했습니다.")
             return
         }
         await nearbyNetwork.send(fileURL: url, info: objectInformation)
+    }
+
+    // TODO: - 사진 데이터를 photo Object와 따로 보내야함! 추후 전송 방식 개선하기
+    private func sendJPEG(
+        photoObject: PhotoObject,
+        type: AirplaINDataType,
+        isDeleted: Bool
+    ) async {
+        let dataInformation = DataInformationDTO(
+            id: photoObject.id,
+            type: .jpg,
+            isDeleted: isDeleted)
+        await nearbyNetwork.send(fileURL: photoObject.photoURL, info: dataInformation)
     }
 }
 
@@ -72,8 +91,29 @@ extension WhiteboardObjectRepository: NearbyNetworkReceiptDelegate {
         didReceiveURL URL: URL,
         info: DataInformationDTO
     ) {
+        if info.type != .jpg {
+            handleWhiteboardObject(didReceiveURL: URL, info: info)
+        } else {
+            handlePhotoData(didReceiveURL: URL, info: info)
+        }
+    }
+
+    private func handlePhotoData(didReceiveURL URL: URL, info: DataInformationDTO) {
         guard let receiveData = filePersistence.load(path: URL) else { return }
-        filePersistence.save(dataInfo: info, data: receiveData)
+        guard let savedURL = filePersistence.save(dataInfo: info, data: receiveData, fileType: ".jpg") else { return }
+
+        if !info.isDeleted {
+            delegate?.whiteboardObjectRepository(
+                self,
+                didReceive: info.id,
+                savedURL: savedURL)
+        }
+    }
+
+    private func handleWhiteboardObject(didReceiveURL URL: URL, info: DataInformationDTO) {
+        guard let receiveData = filePersistence.load(path: URL) else { return }
+
+        filePersistence.save(dataInfo: info, data: receiveData, fileType: nil)
         guard let whiteboardObject = try? JSONDecoder().decode(
             info.type.decodableType,
             from: receiveData)

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00036B822CF56414007D1244 /* PhotoRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */; };
 		003D5A2B2CEB1FF0005F3D09 /* PhotoObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2A2CEB1FEA005F3D09 /* PhotoObject.swift */; };
 		003D5A2D2CEB21AA005F3D09 /* AddPhotoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */; };
 		003D5A2F2CEB21B6005F3D09 /* AddPhotoUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */; };
@@ -76,6 +77,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepositoryInterface.swift; sourceTree = "<group>"; };
 		003D5A2A2CEB1FEA005F3D09 /* PhotoObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoObject.swift; sourceTree = "<group>"; };
 		003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoUseCase.swift; sourceTree = "<group>"; };
 		003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoUseCaseInterface.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				0080E8CD2CE4462E0095B958 /* WhiteboardObjectRepositoryInterface.swift */,
 				A8E97BDA2CE5A6D500B28063 /* ProfileRepositoryInterface.swift */,
 				6F3BCDC92CF31DBA005F6642 /* ChatRepositoryInterface.swift */,
+				00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				A8E97BD92CE5A6B800B28063 /* ProfileIcon.swift in Sources */,
 				A8E97C072CE5E45500B28063 /* WhiteboardObjectSendUseCase.swift in Sources */,
 				A8E97BD82CE5A6B800B28063 /* Profile.swift in Sources */,
+				00036B822CF56414007D1244 /* PhotoRepositoryInterface.swift in Sources */,
 				A85260232CE343B20089DA5E /* ProfileUseCase.swift in Sources */,
 				5BDFD93A2CE2EE3100DA4F5B /* WhiteboardUseCase.swift in Sources */,
 				6F3BCDD02CF3322C005F6642 /* ChatUseCase.swift in Sources */,

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00036B822CF56414007D1244 /* PhotoRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */; };
+		00036B862CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00036B852CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift */; };
 		003D5A2B2CEB1FF0005F3D09 /* PhotoObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2A2CEB1FEA005F3D09 /* PhotoObject.swift */; };
 		003D5A2D2CEB21AA005F3D09 /* AddPhotoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */; };
 		003D5A2F2CEB21B6005F3D09 /* AddPhotoUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */; };
@@ -78,6 +79,7 @@
 
 /* Begin PBXFileReference section */
 		00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepositoryInterface.swift; sourceTree = "<group>"; };
+		00036B852CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectSetInterface.swift; sourceTree = "<group>"; };
 		003D5A2A2CEB1FEA005F3D09 /* PhotoObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoObject.swift; sourceTree = "<group>"; };
 		003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoUseCase.swift; sourceTree = "<group>"; };
 		003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoUseCaseInterface.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 			children = (
 				0080E9192CE4B0880095B958 /* UseCase */,
 				0080E8CC2CE446270095B958 /* Repository */,
+				00036B852CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -446,6 +449,7 @@
 				005BCC512CF01D29001B3623 /* WhiteboardObjectSet.swift in Sources */,
 				A8E97BDB2CE5A6D500B28063 /* ProfileRepositoryInterface.swift in Sources */,
 				A8E97BD92CE5A6B800B28063 /* ProfileIcon.swift in Sources */,
+				00036B862CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift in Sources */,
 				A8E97C072CE5E45500B28063 /* WhiteboardObjectSendUseCase.swift in Sources */,
 				A8E97BD82CE5A6B800B28063 /* Profile.swift in Sources */,
 				00036B822CF56414007D1244 /* PhotoRepositoryInterface.swift in Sources */,

--- a/Domain/Domain/Sources/Entity/PhotoObject.swift
+++ b/Domain/Domain/Sources/Entity/PhotoObject.swift
@@ -43,5 +43,4 @@ public final class PhotoObject: WhiteboardObject {
         try container.encode(photoURL, forKey: .photoURL)
         try super.encode(to: encoder)
     }
-
 }

--- a/Domain/Domain/Sources/Entity/TextObject.swift
+++ b/Domain/Domain/Sources/Entity/TextObject.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public class TextObject: WhiteboardObject {
-    public var text: String
+    public private(set) var text: String
 
     private enum CodingKeys: String, CodingKey { case text }
 
@@ -42,5 +42,9 @@ public class TextObject: WhiteboardObject {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(text, forKey: .text)
         try super.encode(to: encoder)
+    }
+
+    func updateText(text: String) {
+        self.text = text
     }
 }

--- a/Domain/Domain/Sources/Entity/TextObject.swift
+++ b/Domain/Domain/Sources/Entity/TextObject.swift
@@ -44,7 +44,7 @@ public class TextObject: WhiteboardObject {
         try super.encode(to: encoder)
     }
 
-    func updateText(text: String) {
+    func update(text: String) {
         self.text = text
     }
 }

--- a/Domain/Domain/Sources/Interface/Repository/PhotoRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/PhotoRepositoryInterface.swift
@@ -1,0 +1,17 @@
+//
+//  PhotoRepositoryInterface.swift
+//  Domain
+//
+//  Created by 이동현 on 11/26/24.
+//
+
+import Foundation
+
+public protocol PhotoRepositoryInterface {
+    /// 사진을 저장합니다
+    /// - Parameter 
+    ///  id: 사진의 id
+    ///  imageData: 사진 이미지 데이터
+    /// - Returns: 저장한 위치 URL
+    func savePhoto(id: UUID, imageData: Data) -> URL?
+}

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 이동현 on 11/13/24.
 //
+import Foundation
 
 public protocol WhiteboardObjectRepositoryInterface {
     /// WhiteboardObjectRepository의 delegate
@@ -24,4 +25,12 @@ public protocol WhiteboardObjectRepositoryDelegate: AnyObject {
     /// - Parameters:
     ///   - object: 삭제된 화이트보드 오브젝트
     func whiteboardObjectRepository(_ sender: WhiteboardObjectRepositoryInterface, didDelete object: WhiteboardObject)
+
+    /// 사진을 수신하면 실행됩니다.
+    /// - Parameters:
+    ///   - photoID: 추가된 사진의 아이디
+    func whiteboardObjectRepository(
+        _ sender: WhiteboardObjectRepositoryInterface,
+        didReceive photoID: UUID,
+        savedURL: URL)
 }

--- a/Domain/Domain/Sources/Interface/UseCase/AddPhotoUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/AddPhotoUseCaseInterface.swift
@@ -13,11 +13,11 @@ public protocol AddPhotoUseCaseInterface {
     /// - Parameters:
     ///   - imageData: 추가할 사진의 데이터
     ///   - centerPosition: 사진의 중심
-    ///   - size: 사진 객체
-    /// - Returns:
+    ///   - size: 사진의 크기
+    /// - Returns: 사진 객체
     func addPhoto(
         imageData: Data,
         centerPosition: CGPoint,
         size: CGSize
-    ) throws -> PhotoObject
+    ) -> PhotoObject?
 }

--- a/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/TextObjectUseCaseInterface.swift
@@ -16,4 +16,10 @@ public protocol TextObjectUseCaseInterface {
     ///   - size: 현재 뷰의 크기
     /// - Returns: 현재 화면 중앙에 위치한 TextObject를 반환
     func addText(centerPoint: CGPoint, size: CGSize) -> TextObject
+
+    /// TextObject의 text를 수정합니다.
+    /// - Parameters:
+    ///   - id: 수정할 TextObject의 아이디
+    ///   - text: 수정할 text
+    func editText(id: UUID, text: String) async
 }

--- a/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
+++ b/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
@@ -8,13 +8,26 @@
 import Foundation
 
 public protocol WhiteboardObjectSetInterface {
+
+    /// 집합에 오브젝트가 있는지 확인합니다.
+    /// - Parameter object: 확인할 오브젝트
+    /// - Returns: 오브젝트 존재 여부
     func contains(object: WhiteboardObject) async -> Bool
 
+    /// 집합에 오브젝트를 추가합니다.
+    /// - Parameter object: 추가할 오브젝트
     func insert(object: WhiteboardObject) async
 
+    /// 집합에서 오브젝트를 삭제합니다.
+    /// - Parameter object: 삭제할 오브젝트
     func remove(object: WhiteboardObject) async
 
+    /// 집합에 있는 오브젝트를 업데이트 합니다.
+    /// - Parameter object: 업데이트할 오브젝트
     func update(object: WhiteboardObject) async
-
+    
+    /// ID로 집합에있는 오브젝트를 가져옵니다.
+    /// - Parameter id: 가져올 오브젝트의 ID
+    /// - Returns: 오브젝트
     func fetchObjectByID(id: UUID) async -> WhiteboardObject?
 }

--- a/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
+++ b/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
@@ -1,0 +1,20 @@
+//
+//  WhiteboardObjectSetInterface.swift
+//  Domain
+//
+//  Created by 이동현 on 11/26/24.
+//
+
+import Foundation
+
+public protocol WhiteboardObjectSetInterface {
+    func contains(object: WhiteboardObject) async -> Bool
+
+    func insert(object: WhiteboardObject) async
+
+    func remove(object: WhiteboardObject) async
+
+    func update(object: WhiteboardObject) async
+
+    func fetchObjectByID(id: UUID) async -> WhiteboardObject?
+}

--- a/Domain/Domain/Sources/Model/WhiteboardObjectSet.swift
+++ b/Domain/Domain/Sources/Model/WhiteboardObjectSet.swift
@@ -7,27 +7,31 @@
 
 import Foundation
 
-actor WhiteboardObjectSet {
-    private var whiteboardObjects: Set<WhiteboardObject> = []
+public actor WhiteboardObjectSet: WhiteboardObjectSetInterface {
+    private var whiteboardObjects: Set<WhiteboardObject>
 
-    func contains(object: WhiteboardObject) -> Bool {
+    public init() {
+        whiteboardObjects = []
+    }
+
+    public func contains(object: WhiteboardObject) -> Bool {
         return whiteboardObjects.contains(object)
     }
 
-    func insert(object: WhiteboardObject) {
+    public func insert(object: WhiteboardObject) {
         whiteboardObjects.insert(object)
     }
 
-    func remove(object: WhiteboardObject) {
+    public func remove(object: WhiteboardObject) {
         whiteboardObjects.remove(object)
     }
 
-    func update(object: WhiteboardObject) {
+    public func update(object: WhiteboardObject) {
         remove(object: object)
         insert(object: object)
     }
 
-    func fetchObjectByID(id: UUID) -> WhiteboardObject? {
+    public func fetchObjectByID(id: UUID) -> WhiteboardObject? {
         return whiteboardObjects.first { $0.id == id }
     }
 }

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -14,7 +14,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
     public var removedObjectPublisher: AnyPublisher<WhiteboardObject, Never>
     public var selectedObjectIDPublisher: AnyPublisher<UUID?, Never>
 
-    private var whiteboardObjectSet: WhiteboardObjectSet
+    private var whiteboardObjectSet: WhiteboardObjectSetInterface
 
     private let addedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
     private let updatedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
@@ -25,7 +25,8 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     public init(
         profileRepository: ProfileRepositoryInterface,
-        whiteboardRepository: WhiteboardObjectRepositoryInterface
+        whiteboardRepository: WhiteboardObjectRepositoryInterface,
+        whiteboardObjectSet: WhiteboardObjectSetInterface
     ) {
         addedWhiteboardSubject = PassthroughSubject<WhiteboardObject, Never>()
         updatedWhiteboardSubject = PassthroughSubject<WhiteboardObject, Never>()
@@ -37,7 +38,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         removedObjectPublisher = removedWhiteboardSubject.eraseToAnyPublisher()
         selectedObjectIDPublisher = selectedObjectIDSubject.eraseToAnyPublisher()
 
-        whiteboardObjectSet = WhiteboardObjectSet()
+        self.whiteboardObjectSet = whiteboardObjectSet
         myProfile = profileRepository.loadProfile()
         self.whiteboardObjectRepository = whiteboardRepository
     }

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -139,6 +139,20 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 extension ManageWhiteboardObjectUseCase: WhiteboardObjectRepositoryDelegate {
     public func whiteboardObjectRepository(
         _ sender: any WhiteboardObjectRepositoryInterface,
+        didReceive photoID: UUID,
+        savedURL: URL
+    ) {
+        Task {
+            guard
+                let photoObject = await whiteboardObjectSet
+                    .fetchObjectByID(id: photoID) as? PhotoObject
+            else { return }
+            await updateObject(whiteboardObject: photoObject)
+        }
+    }
+
+    public func whiteboardObjectRepository(
+        _ sender: any WhiteboardObjectRepositoryInterface,
         didReceive object: WhiteboardObject
     ) {
         Task {

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -30,7 +30,7 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
             let texboardObject = await whiteboardObjectSet
                 .fetchObjectByID(id: id) as? TextObject
         else { return }
-  
+
         texboardObject.updateText(text: text)
         await whiteboardObjectSet.update(object: texboardObject)
     }

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -31,7 +31,7 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
                 .fetchObjectByID(id: id) as? TextObject
         else { return }
 
-        texboardObject.updateText(text: text)
+        texboardObject.update(text: text)
         await whiteboardObjectSet.update(object: texboardObject)
     }
 }

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -10,8 +10,10 @@ import Foundation
 
 public final class TextObjectUseCase: TextObjectUseCaseInterface {
     private let textFieldDefaultSize: CGSize
+    private let whiteboardObjectSet: WhiteboardObjectSet
 
-    public init(textFieldDefaultSize: CGSize) {
+    public init(whiteboardObjectSet: WhiteboardObjectSet, textFieldDefaultSize: CGSize) {
+        self.whiteboardObjectSet = whiteboardObjectSet
         self.textFieldDefaultSize = textFieldDefaultSize
     }
 
@@ -21,5 +23,15 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
             centerPosition: point,
             size: textFieldDefaultSize,
             text: "Hello, AirplaIN!")
+    }
+
+    public func editText(id: UUID, text: String) async {
+        guard
+            let texboardObject = await whiteboardObjectSet
+                .fetchObjectByID(id: id) as? TextObject
+        else { return }
+  
+        texboardObject.updateText(text: text)
+        await whiteboardObjectSet.update(object: texboardObject)
     }
 }

--- a/Domain/DomainTests/AddPhotoUseCaseTests.swift
+++ b/Domain/DomainTests/AddPhotoUseCaseTests.swift
@@ -8,17 +8,19 @@
 import Domain
 import XCTest
 
+final class MockPhotoRepository: PhotoRepositoryInterface {
+    func savePhoto(id: UUID, imageData: Data) -> URL? {
+        return URL(filePath: "photo.jpg")
+    }
+}
+
 final class AddPhotoUseCaseTests: XCTestCase {
     private var useCase: AddPhotoUseCase!
 
     override func setUp() {
         super.setUp()
-
-        do {
-            useCase = try AddPhotoUseCase()
-        } catch {
-            XCTFail("init photoUseCase should success.")
-        }
+        let mockPhotoRepository = MockPhotoRepository()
+        useCase =  AddPhotoUseCase(photoRepository: mockPhotoRepository)
     }
 
     override func tearDown() {
@@ -32,21 +34,17 @@ final class AddPhotoUseCaseTests: XCTestCase {
         let dummyImageData = Data()
         let position = CGPoint(x: 100, y: 100)
         let size = CGSize(width: 200, height: 200)
-        let photoObject: PhotoObject
+        let photoObject: PhotoObject?
 
         // 실행
-        do {
-            photoObject = try useCase.addPhoto(
-                imageData: dummyImageData,
-                centerPosition: position,
-                size: size)
-        } catch {
-            XCTFail("photoObject should not fail.")
-            return
-        }
+        photoObject = useCase.addPhoto(
+            imageData: dummyImageData,
+            centerPosition: position,
+            size: size)
 
         // 검증
-        XCTAssertEqual(photoObject.photoURL.lastPathComponent.suffix(4), ".jpg")
+        XCTAssertNotNil(photoObject)
+        guard let photoObject else { return }
         XCTAssertEqual(photoObject.centerPosition, position)
         XCTAssertEqual(photoObject.size, size)
     }

--- a/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
+++ b/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
@@ -20,7 +20,8 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
 
         useCase = ManageWhiteboardObjectUseCase(
             profileRepository: profileRepository,
-            whiteboardRepository: MockWhiteObjectRepository())
+            whiteboardRepository: MockWhiteObjectRepository(),
+            whiteboardObjectSet: WhiteboardObjectSet())
         cancellables = []
     }
 

--- a/Domain/DomainTests/TextObjectUseCaseTests.swift
+++ b/Domain/DomainTests/TextObjectUseCaseTests.swift
@@ -13,7 +13,7 @@ final class TextObjectUseCaseTests: XCTestCase {
 
     override func setUpWithError() throws {
         let mockCGSize = CGSize(width: 200, height: 50)
-        useCase = TextObjectUseCase(textFieldDefaultSize: mockCGSize)
+        useCase = TextObjectUseCase(whiteboardObjectSet: WhiteboardObjectSet(), textFieldDefaultSize: mockCGSize)
     }
 
     override func tearDownWithError() throws {

--- a/Persistence/Persistence/Souces/FilePersistence.swift
+++ b/Persistence/Persistence/Souces/FilePersistence.swift
@@ -18,7 +18,11 @@ public struct FilePersistence: FilePersistenceInterface {
 
     public init() {}
 
-    public func save(dataInfo: DataInformationDTO, data: Data?) -> URL? {
+    public func save(
+        dataInfo: DataInformationDTO,
+        data: Data?,
+        fileType: String? = nil
+    ) -> URL? {
         guard let directoryURL = documentDirectoryURL?
             .appendingPathComponent(
                 dataInfo
@@ -31,7 +35,8 @@ public struct FilePersistence: FilePersistenceInterface {
         return write(
             to: directoryURL,
             with: data,
-            fileName: dataInfo.id.uuidString)
+            fileName: dataInfo.id.uuidString,
+            fileType: fileType)
     }
 
     public func load(path: URL) -> Data? {
@@ -60,9 +65,16 @@ public struct FilePersistence: FilePersistenceInterface {
     private func write(
         to url: URL,
         with data: Data?,
-        fileName: String
+        fileName: String,
+        fileType: String? = nil
     ) -> URL {
-        let fileURL = url.appendingPathComponent("\(fileName).json")
+        let fileURL: URL
+
+        if let fileType {
+            fileURL = url.appendingPathComponent("\(fileName).\(fileType)")
+        } else {
+            fileURL = url.appendingPathComponent("\(fileName).json")
+        }
 
         do {
             try data?.write(to: fileURL)

--- a/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
@@ -5,15 +5,17 @@
 //  Created by 이동현 on 11/12/24.
 //
 import Domain
-import Foundation
+import UIKit
 
 public protocol WhiteboardObjectViewFactoryable {
     var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate? { get set }
+    var textViewDelegate: UITextViewDelegate? { get set }
     func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView?
 }
 
 public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
     public weak var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate?
+    public weak var textViewDelegate: UITextViewDelegate?
 
     public init() {}
 
@@ -22,7 +24,7 @@ public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
 
         switch whiteboardObject {
         case let textObject as TextObject:
-            whiteboardObjectView = TextObjectView(textObject: textObject)
+            whiteboardObjectView = TextObjectView(textObject: textObject, textViewDelegate: textViewDelegate)
         case let drawingObject as DrawingObject:
             whiteboardObjectView = DrawingObjectView(drawingObject: drawingObject)
         case let photoObject as PhotoObject:

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
@@ -15,7 +15,7 @@ final class PhotoObjectView: WhiteboardObjectView {
         super.init(whiteboardObject: photoObject)
         configureAttribute()
         configureLayout()
-        configureImage(with: photoObject)
+        configureImage(with: photoObject.photoURL)
     }
 
     required init?(coder: NSCoder) {
@@ -33,9 +33,9 @@ final class PhotoObjectView: WhiteboardObjectView {
         super.configureLayout()
     }
 
-    private func configureImage(with object: PhotoObject) {
+    private func configureImage(with imageURL: URL) {
         guard
-            let imageData = try? Data(contentsOf: object.photoURL),
+            let imageData = try? Data(contentsOf: imageURL),
             let image = UIImage(data: imageData)
         else { return }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -19,18 +19,17 @@ final class TextObjectView: WhiteboardObjectView {
         return textView
     }()
 
-    init(textObject: TextObject) {
+    init(
+        textObject: TextObject,
+        textViewDelegate: UITextViewDelegate?
+    ) {
         super.init(whiteboardObject: textObject)
-        configureAttribute()
         configureLayout()
+        textView.delegate = textViewDelegate
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-    }
-
-    private func configureAttribute() {
-        textView.delegate = self
     }
 
     override func configureLayout() {
@@ -50,27 +49,5 @@ final class TextObjectView: WhiteboardObjectView {
     override func configureEditable(isEditable: Bool) {
         super.configureEditable(isEditable: isEditable)
         textView.isUserInteractionEnabled = isEditable
-    }
-}
-
-extension TextObjectView: UITextViewDelegate {
-    func textView(
-        _ textView: UITextView,
-        shouldChangeTextIn range: NSRange,
-        replacementText text: String
-    ) -> Bool {
-        guard text != "\n" else {
-            textView.resignFirstResponder()
-            return false
-        }
-
-        let maxLength = 15
-        guard let originText = textView.text else { return true }
-        let newlength = originText.count + text.count - range.length
-        return newlength < maxLength
-    }
-
-    func textViewDidEndEditing(_ textView: UITextView) {
-        // TODO: - TextView 수정 로직 추가
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -38,6 +38,7 @@ public final class WhiteboardViewController: UIViewController {
         whiteboardObjectViews = [:]
         super.init(nibName: nil, bundle: nil)
         self.objectViewFactory.whiteboardObjectViewDelegate = self
+        self.objectViewFactory.textViewDelegate = self
     }
 
     public required init?(coder: NSCoder) {
@@ -284,5 +285,28 @@ extension WhiteboardViewController: WhiteboardObjectViewDelegate {
 
     public func whiteboardObjectViewDidEndMoving(_ sender: WhiteboardObjectView, newCenter: CGPoint) {
         viewModel.action(input: .changeObjectPosition(point: newCenter))
+    }
+}
+
+extension WhiteboardViewController: UITextViewDelegate {
+    public func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        guard text != "\n" else {
+            textView.resignFirstResponder()
+            viewModel.action(input: .editTextObject(text: textView.text ?? ""))
+            return false
+        }
+
+        let maxLength = 20
+        guard let originText = textView.text else { return true }
+        let newlength = originText.count + text.count - range.length
+        return newlength < maxLength
+    }
+
+    public func textViewDidEndEditing(_ textView: UITextView) {
+        viewModel.action(input: .editTextObject(text: textView.text ?? ""))
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -20,6 +20,7 @@ public final class WhiteboardViewModel: ViewModel {
         case finishDrawing
         case finishUsingTool
         case addTextObject(point: CGPoint, viewSize: CGSize)
+        case editTextObject(text: String)
         case selectObject(objectID: UUID)
         case deselectObject
         case changeObjectScaleAndAngle(scale: CGFloat, angle: CGFloat)
@@ -93,6 +94,8 @@ public final class WhiteboardViewModel: ViewModel {
             finishUsingTool()
         case .addTextObject(let point, let viewSize):
             addText(at: point, viewSize: viewSize)
+        case .editTextObject(let text):
+            editText(text: text)
         case .selectObject(let objectID):
             selectObject(objectID: objectID)
         case .deselectObject:
@@ -157,6 +160,13 @@ public final class WhiteboardViewModel: ViewModel {
     private func addText(at point: CGPoint, viewSize: CGSize) {
         let textObject = textObjectUseCase.addText(centerPoint: point, size: viewSize)
         addWhiteboardObject(object: textObject)
+    }
+
+    private func editText(text: String) {
+        guard let selectedObjectID = selectedObjectSubject.value else { return }
+        Task {
+            await textObjectUseCase.editText(id: selectedObjectID, text: text)
+        }
     }
 
     private func startPublishing() {

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -129,16 +129,15 @@ public final class WhiteboardViewModel: ViewModel {
         point: CGPoint,
         size: CGSize
     ) {
-        do {
-            let photoObject = try addPhotoUseCase.addPhoto(
+        guard
+            let photoObject = addPhotoUseCase.addPhoto(
                 imageData: imageData,
                 centerPosition: point,
                 size: size)
-            Task {
-                await manageWhiteboardObjectUseCase.addObject(whiteboardObject: photoObject)
-            }
-        } catch {
-        // TODO: - 사진 추가 실패 시 오류 처리
+        else { return }
+
+        Task {
+            await manageWhiteboardObjectUseCase.addObject(whiteboardObject: photoObject)
         }
     }
 

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -260,8 +260,9 @@ extension WhiteboardListViewController: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let selectedWhiteboard = dataSource?.itemIdentifier(for: indexPath) else { return }
         viewModel.action(input: .joinWhiteboard(whiteboard: selectedWhiteboard))
-        let whiteboardViewController = WhiteboardViewController(viewModel: whiteboardViewModel,
-                                                                objectViewFactory: whiteboardObjectViewFactory)
+        let whiteboardViewController = WhiteboardViewController(
+            viewModel: whiteboardViewModel,
+            objectViewFactory: whiteboardObjectViewFactory)
         self.navigationController?.isNavigationBarHidden = false
         self.navigationController?.pushViewController(whiteboardViewController, animated: true)
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 오브젝트 수정 기능 완성


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- TextObject 수정 기능 추가
- 사진 오브젝트 전송 시, 사진 데이터도 함께 전송

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 시뮬레이터 빌드 후 테스트
- 시간 상의 이유로 텍스트 수정 테스트코드는 작성하지 못했습니다.


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- TextObject를 적절한 방법으로 수정해야하는데, 시간 상의 이유로 간단한 방법으로 해결하고자 했습니다. TextObjectView를 생성할 때 UITextViewDelegate를 채택한 VC를 파라미터로 넘겨주는 방법인데요, 이로서 TextObjectView의 TextView에서 일어나는 action들을 VC가 감지하고 처리하게 됩니다. 점점 키메라가 되어가는거 같은데,, 개선 사항이 하나 둘 씩 늘어나고 있군요
- 사진 오브젝트를 전송할 때, 파일 시스템에 저장한 사진은 안넘기고 저장한 사진의 url만 넘기고 있다는 것을 알았습니다. 이에 사진 오브젝트는 수정/추가 시 따로 사진 데이터를 전송하는 코드를 작성했습니다. 다만 문제점이 있는데요, 사진의 정보가 수정될 때, 원본 사진 데이터는 전송할 필요가 없지만 항상 같이 전송한다는 문제가 있습니다. 이 부분은 **개선 포인트 0순위**라고 생각합니다. 

