### PR TITLE
[Feature] 화이트보드 연결 끊기 로직 구현

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -26,6 +26,9 @@ public protocol NearbyNetworkInterface {
 
     /// 주변에 내 기기 알리는 것을 중지합니다.
     func stopPublishing()
+    
+    /// 연결된 모든 피어와 연결을 끊습니다. 
+    func disconnectAll()
 
     /// 주변 기기와 연결을 시도합니다.
     /// - Parameter connection: 연결할 기기

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -34,6 +34,11 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         nearbyNetwork.startSearching()
     }
 
+    public func disconnectWhiteboard() {
+        nearbyNetwork.disconnectAll()
+        nearbyNetwork.stopPublishing()
+    }
+
     public func joinWhiteboard(whiteboard: Whiteboard, myProfile: Profile) throws {
         let profileIcons = whiteboard.participantIcons
             .map { $0.emoji }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -18,9 +18,12 @@ public protocol WhiteboardRepositoryInterface {
 
     /// 화이트보드 탐색을 중지합니다.
     func stopSearching()
-    
+
     /// 화이트보드 탐색을 중단 후 다시 시작합니다. 
     func restartSearching()
+    
+    /// 화이트보드와 연결을 끊습니다. 
+    func disconnectWhiteboard()
 
     /// 선택한 화이트보드와 연결을 시도합니다.
     /// - Parameter whiteboard: 연결할 화이트보드

--- a/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
@@ -18,6 +18,9 @@ public protocol WhiteboardUseCaseInterface {
 
     /// 주변 화이트보드를 탐색합니다.
     func startSearchingWhiteboard()
+    
+    /// 화이트보드와 연결을 끊습니다. 
+    func disconnectWhiteboard()
 
     /// 선택한 화이트보드와 연결을 시도합니다.
     /// - Parameter whiteboard: 연결할 화이트보드

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -46,6 +46,10 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
         whiteboardRepository.stopSearching()
     }
 
+    public func disconnectWhiteboard() {
+        whiteboardRepository.disconnectWhiteboard()
+    }
+
     public func joinWhiteboard(whiteboard: Whiteboard) throws {
         let profile = profileRepository.loadProfile()
         try whiteboardRepository.joinWhiteboard(whiteboard: whiteboard, myProfile: profile)

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -76,6 +76,10 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         serviceAdvertiser.stopAdvertisingPeer()
     }
 
+    public func disconnectAll() {
+        session.disconnect()
+    }
+
     public func joinConnection(connection: NetworkConnection, context: RequestedContext) throws {
         isHost = false
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -55,6 +55,7 @@ public final class WhiteboardViewController: UIViewController {
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.isNavigationBarHidden = true
+        viewModel.action(input: .disconnectWhiteboard)
     }
 
     private func configureAttribute() {

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -25,6 +25,7 @@ public final class WhiteboardViewModel: ViewModel {
         case changeObjectScaleAndAngle(scale: CGFloat, angle: CGFloat)
         case changeObjectPosition(point: CGPoint)
         case deleteObject
+        case disconnectWhiteboard
     }
 
     struct Output {
@@ -103,6 +104,8 @@ public final class WhiteboardViewModel: ViewModel {
             changeObjectPosition(to: position)
         case .deleteObject:
             deleteObject()
+        case .disconnectWhiteboard:
+            disconnectWhiteboard()
         }
     }
 
@@ -205,5 +208,9 @@ public final class WhiteboardViewModel: ViewModel {
             let isSuccess = await manageWhiteboardObjectUseCase.removeObject(whiteboardObjectID: selectedObjectID)
             if isSuccess { selectedObjectSubject.send(nil) }
         }
+    }
+
+    private func disconnectWhiteboard() {
+        whiteboardUseCase.disconnectWhiteboard()
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 화이트보드 화면에서 리스트 화면으로 나갈 때 연결을 끊는 로직을 추가했습니다. 
- 퍼블리싱 역시 중단됩니다. 

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/dfe9b5f0-36d2-4ac2-9e8e-6d98936ff793

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 화이트보드 연결 끊는 로직 구현
    - `MCSession`의 `disconnect()`메서드 활용했습니다. 
    - host 여부에 상관 없이 퍼블리싱을 중단하지만, 참여자는 퍼블리싱을 하지 않기에 상관없다고 판단했습니다. 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #17 