### PR TITLE
[Refactor] ReceiptDelegate를 퍼블리셔로 수정

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -5,11 +5,13 @@
 //  Created by 최정인 on 11/7/24.
 //
 
+import Combine
 import Foundation
 
 public protocol NearbyNetworkInterface {
+    var reciptDataPublisher: AnyPublisher<Data, Never> { get }
+    var reciptURLPublisher: AnyPublisher<(url: URL, dataInfo: DataInformationDTO), Never> { get }
     var connectionDelegate: NearbyNetworkConnectionDelegate? { get set }
-    var receiptDelegate: NearbyNetworkReceiptDelegate? { get set }
 
     /// 주변 기기를 검색합니다.
     func startSearching()
@@ -91,20 +93,4 @@ public protocol NearbyNetworkConnectionDelegate: AnyObject {
         _ sender: NearbyNetworkInterface,
         didDisconnect connection: NetworkConnection,
         isHost: Bool)
-}
-
-public protocol NearbyNetworkReceiptDelegate: AnyObject {
-    /// 데이터를 수신했을 때 실행됩니다.
-    /// - Parameters:
-    ///   - data: 수신된 데이터
-    func nearbyNetwork(_ sender: NearbyNetworkInterface, didReceive data: Data)
-
-    /// 파일을 수신했을 때 실행됩니다.
-    /// - Parameters:
-    ///  - URL: 수신한 파일의 URL
-    ///  - info: 파일에 대한 정보
-    func nearbyNetwork(
-        _ sender: NearbyNetworkInterface,
-        didReceiveURL URL: URL,
-        info: DataInformationDTO)
 }

--- a/DataSource/DataSource/Sources/Repository/ChatRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/ChatRepository.swift
@@ -5,6 +5,7 @@
 //  Created by 박승찬 on 11/24/24.
 //
 
+import Combine
 import Domain
 import OSLog
 
@@ -12,6 +13,7 @@ public final class ChatRepository: ChatRepositoryInterface {
     public weak var delegate: ChatRepositoryDelegate?
     private var nearbyNetwork: NearbyNetworkInterface
     private let filePersistence: FilePersistenceInterface
+    private var cancellables: Set<AnyCancellable>
     private let logger = Logger()
 
     init(
@@ -22,7 +24,8 @@ public final class ChatRepository: ChatRepositoryInterface {
         self.delegate = delegate
         self.nearbyNetwork = nearbyNetwork
         self.filePersistence = filePersistence
-        self.nearbyNetwork.receiptDelegate = self
+        cancellables = []
+        bindNearbyNetwork()
     }
 
     public func send(message: String, profile: Profile) async -> ChatMessage? {
@@ -46,20 +49,24 @@ public final class ChatRepository: ChatRepositoryInterface {
 
         return chatMessage
     }
-}
 
-extension ChatRepository: NearbyNetworkReceiptDelegate {
-    // TODO: 사용안할 메소드
-    public func nearbyNetwork(_ sender: any NearbyNetworkInterface, didReceive data: Data) { }
+    private func bindNearbyNetwork() {
+        nearbyNetwork.reciptURLPublisher
+            .sink { [weak self] url, dataInfo in
+                switch dataInfo.type {
+                case .chat:
+                    self?.handleChatData(url: url, dataInfo: dataInfo)
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+    }
 
-    public func nearbyNetwork(
-        _ sender: any NearbyNetworkInterface,
-        didReceiveURL URL: URL,
-        info: DataInformationDTO
-    ) {
-        guard let receivedData = filePersistence.load(path: URL) else { return }
+    private func handleChatData(url: URL, dataInfo: DataInformationDTO) {
+        guard let receivedData = filePersistence.load(path: url) else { return }
         filePersistence.save(
-            dataInfo: info,
+            dataInfo: dataInfo,
             data: receivedData,
             fileType: nil)
         guard

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -5,6 +5,7 @@
 //  Created by 최정인 on 11/7/24.
 //
 
+import Combine
 import DataSource
 import Foundation
 import MultipeerConnectivity
@@ -12,7 +13,10 @@ import OSLog
 
 public final class NearbyNetworkService: NSObject {
     public weak var connectionDelegate: NearbyNetworkConnectionDelegate?
-    public weak var receiptDelegate: NearbyNetworkReceiptDelegate?
+    public let reciptDataPublisher: AnyPublisher<Data, Never>
+    public let reciptURLPublisher: AnyPublisher<(url: URL, dataInfo: DataInformationDTO), Never>
+    private let reciptDataSubject = PassthroughSubject<Data, Never>()
+    private let reciptURLSubject = PassthroughSubject<(url: URL, dataInfo: DataInformationDTO), Never>()
     private let peerID: MCPeerID
     private let session: MCSession
     private var serviceAdvertiser: MCNearbyServiceAdvertiser
@@ -34,6 +38,9 @@ public final class NearbyNetworkService: NSObject {
             discoveryInfo: nil,
             serviceType: serviceName)
         serviceBrowser = MCNearbyServiceBrowser(peer: peerID, serviceType: serviceName)
+
+        reciptDataPublisher = reciptDataSubject.eraseToAnyPublisher()
+        reciptURLPublisher = reciptURLSubject.eraseToAnyPublisher()
 
         super.init()
 
@@ -190,7 +197,7 @@ extension NearbyNetworkService: MCSessionDelegate {
             logger.log(level: .error, "\(peerID.displayName)와 연결되어 있지 않음")
             return
         }
-        receiptDelegate?.nearbyNetwork(self, didReceive: data)
+        reciptDataSubject.send(data)
     }
 
     public func session(
@@ -224,10 +231,7 @@ extension NearbyNetworkService: MCSessionDelegate {
             let dto = try? JSONDecoder().decode(DataInformationDTO.self, from: jsonData)
         else { return }
 
-        receiptDelegate?.nearbyNetwork(
-            self,
-            didReceiveURL: localURL,
-            info: dto)
+        reciptURLSubject.send((url: localURL, dataInfo: dto))
     }
 }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
기존 delegate를 통해 데이터 플로우를 관리해주던 설계가 잘못됨을 느꼈습니다.
여러 레포지터리에서 하나의 delegate를 NearbyNetwrok에 주입시켜주고 있어, 이전에 주입한 delegate들이 무시되는 현상을 겪었습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
몹 프로그래밍을 통해 ReciptDelegate를 퍼블리셔로 수정 했습니다.
delegate를 여러개 작성하고 채택하는 것 보다, 퍼블리셔 하나로 처리해주는 플로우가 현재 구조에 알맞다고 판단했습니다.