### PR TITLE
[Feature] 화이트보드 내 Wordle 플레이 구현

### DIFF
--- a/DataSource/DataSource/Sources/Repository/GameRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/GameRepository.swift
@@ -33,6 +33,15 @@ public final class GameRepository: GameRepositoryInterface {
         persistenceService.save(data: wordleAnswerSet, forKey: wordleAnswerKey)
     }
 
+    public func containsWord(word: String) -> Bool {
+        guard
+            let wordleSet: [String] = persistenceService.load(forKey: wordleAnswerKey),
+            wordleSet.contains(word)
+        else { return false }
+
+        return true
+    }
+
     public func loadWordleHistory(gameID: UUID) -> [String] {
         guard
             let wordleHistory: [UUID: [String]] = persistenceService.load(forKey: wordleAnswerKey),

--- a/DataSource/DataSource/Sources/Repository/GameRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/GameRepository.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public final class GameRepository: GameRepositoryInterface {
     private let persistenceService: PersistenceInterface
-    private let wordleKey = "AirplainWordle"
+    private let wordleAnswerKey = "AirplainWordle"
+    private let wordleHistoryKey = "AirplainWordleHistory"
 
     public init(persistenceService: PersistenceInterface) {
         self.persistenceService = persistenceService
@@ -18,18 +19,31 @@ public final class GameRepository: GameRepositoryInterface {
 
     public func randomGameAnswer() -> String {
         guard
-            let wordleSet: [String] = persistenceService.load(forKey: wordleKey),
+            let wordleSet: [String] = persistenceService.load(forKey: wordleAnswerKey),
             let wordleAnswer = wordleSet.randomElement()
         else {
-            saveWordleSet(wordleSet: gameWords)
+            saveWordleAnswerSet(wordleAnswerSet: gameWords)
             return gameWords.randomElement() ?? "KOREA"
         }
 
         return wordleAnswer
     }
 
-    public func saveWordleSet(wordleSet: [String]) {
-        persistenceService.save(data: wordleSet, forKey: wordleKey)
+    public func saveWordleAnswerSet(wordleAnswerSet: [String]) {
+        persistenceService.save(data: wordleAnswerSet, forKey: wordleAnswerKey)
+    }
+
+    public func loadWordleHistory(gameID: UUID) -> [String] {
+        guard
+            let wordleHistory: [UUID: [String]] = persistenceService.load(forKey: wordleAnswerKey),
+            let gameHistory = wordleHistory[gameID]
+        else { return [] }
+        return gameHistory
+    }
+
+    public func saveWordleHistory(gameID: UUID, wordleHistory: [String]) {
+        let gameHistory: [UUID: [String]] = [gameID: wordleHistory]
+        persistenceService.save(data: gameHistory, forKey: wordleHistoryKey)
     }
 }
 

--- a/Domain/Domain/Sources/Interface/Repository/GameRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/GameRepositoryInterface.swift
@@ -5,12 +5,25 @@
 //  Created by 최정인 on 11/27/24.
 //
 
+import Foundation
+
 public protocol GameRepositoryInterface {
     /// 랜덤한 게임 정답을 반환합니다.
     /// - Returns: 랜덤 게임 정답
     func randomGameAnswer() -> String
 
     /// 게임 정답 Set을 저장합니다.
-    /// - Parameter wordleSet: 게임 정답 Set
-    func saveWordleSet(wordleSet: [String])
+    /// - Parameter wordleAnswerSet: 게임 정답 Set
+    func saveWordleAnswerSet(wordleAnswerSet: [String])
+
+    /// 저장된 게임 기록을 불러옵니다.
+    /// - Parameter gameID: 게임 기록을 불러올 게임 ID
+    /// - Returns: 게임 History
+    func loadWordleHistory(gameID: UUID) -> [String]
+
+    /// 게임 기록을 저장합니다.
+    /// - Parameters:
+    ///   - gameID: 기록을 저장할 게임 ID
+    ///   - wordleHistory: 게임 History
+    func saveWordleHistory(gameID: UUID, wordleHistory: [String])
 }

--- a/Domain/Domain/Sources/Interface/Repository/GameRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/GameRepositoryInterface.swift
@@ -16,6 +16,11 @@ public protocol GameRepositoryInterface {
     /// - Parameter wordleAnswerSet: 게임 정답 Set
     func saveWordleAnswerSet(wordleAnswerSet: [String])
 
+    /// 입력한 단어가 게임 정답 Set에 포함되어 있는지 여부를 판단합니다.
+    /// - Parameter word: 입력한 단어
+    /// - Returns: 게임 정답 Set 포함 여부
+    func containsWord(word: String) -> Bool
+
     /// 저장된 게임 기록을 불러옵니다.
     /// - Parameter gameID: 게임 기록을 불러올 게임 ID
     /// - Returns: 게임 History

--- a/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
@@ -10,12 +10,14 @@ import UIKit
 public protocol WhiteboardObjectViewFactoryable {
     var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate? { get set }
     var textViewDelegate: UITextViewDelegate? { get set }
+    var gameObjectDelegate: GameObjectDelegate? { get set }
     func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView?
 }
 
 public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
     public weak var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate?
     public weak var textViewDelegate: UITextViewDelegate?
+    public weak var gameObjectDelegate: GameObjectDelegate?
 
     public init() {}
 
@@ -30,7 +32,7 @@ public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
         case let photoObject as PhotoObject:
             whiteboardObjectView = PhotoObjectView(photoObject: photoObject)
         case let gameObject as GameObject:
-            whiteboardObjectView = GameObjectView(gameObject: gameObject)
+            whiteboardObjectView = GameObjectView(gameObject: gameObject, gameObjectDelegate: gameObjectDelegate)
         default:
             whiteboardObjectView = nil
         }

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -8,7 +8,11 @@
 import Combine
 import Domain
 import PhotosUI
+import SwiftUI
 import UIKit
+// TODO: 추후 개선
+import DataSource
+import Persistence
 
 public final class WhiteboardViewController: UIViewController {
     private enum WhiteboardLayoutConstant {
@@ -39,6 +43,7 @@ public final class WhiteboardViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         self.objectViewFactory.whiteboardObjectViewDelegate = self
         self.objectViewFactory.textViewDelegate = self
+        self.objectViewFactory.gameObjectDelegate = self
     }
 
     public required init?(coder: NSCoder) {
@@ -51,6 +56,11 @@ public final class WhiteboardViewController: UIViewController {
         configureAttribute()
         configureScrollView()
         bind()
+    }
+
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = false
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
@@ -312,5 +322,17 @@ extension WhiteboardViewController: UITextViewDelegate {
 
     public func textViewDidEndEditing(_ textView: UITextView) {
         viewModel.action(input: .editTextObject(text: textView.text ?? ""))
+    }
+}
+
+extension WhiteboardViewController: GameObjectDelegate {
+    public func gameObjectDelegateDidDoubleTap(_ sender: GameObjectView, gameObject: GameObject) {
+        viewModel.action(input: .deselectObject)
+        let gameRepository = GameRepository(persistenceService: PersistenceService())
+        let wordelViewModel = WordleViewModel(gameRepository: gameRepository, gameObject: gameObject)
+        let wordleView = WordleView(viewModel: wordelViewModel)
+        let hostingController = UIHostingController(rootView: NavigationStack { wordleView })
+        hostingController.modalPresentationStyle = .fullScreen
+        present(hostingController, animated: true)
     }
 }

--- a/Presentation/Presentation/Sources/Wordle/View/WordleView.swift
+++ b/Presentation/Presentation/Sources/Wordle/View/WordleView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct WordleView: View {
+    @Environment(\.dismiss) private var dismiss
     @StateObject var viewModel: WordleViewModel
     @State private var isShowingGuideView: Bool = false
 
@@ -47,7 +48,7 @@ struct WordleView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
-                        // TODO: Dismiss
+                        dismiss()
                     } label: {
                         Image(systemName: "xmark")
                             .foregroundStyle(.airplainBlack)
@@ -77,7 +78,7 @@ struct WordleView: View {
                     width: WordleViewLayoutConstant.wordleAnswerWidth,
                     height: WordleViewLayoutConstant.wordleAnswerHeight)
 
-            Text(viewModel.answerWord)
+            Text(viewModel.gameObjcet.gameAnswer)
                 .foregroundStyle(.white)
                 .font(Font(AirplainFont.Subtitle2))
         }

--- a/Presentation/Presentation/Sources/Wordle/ViewModel/WordleViewModel.swift
+++ b/Presentation/Presentation/Sources/Wordle/ViewModel/WordleViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Domain
 import Foundation
 
 final class WordleViewModel: ObservableObject {
@@ -48,15 +49,22 @@ final class WordleViewModel: ObservableObject {
     @Published private(set) var isGameOver = false
     @Published private(set) var canSubmitWordle = false
 
+    private let gameRepository: GameRepositoryInterface
+    let gameObjcet: GameObject
+    private var triedWordleCount = 0
     let wordleWordCount = 5
     let wordleTryCount = 6
-    private var triedWordleCount = 0
-
-    // TODO: Persistance에서 정답 꺼내오기
-    let answerWord = "MONEY"
 
     enum Input {
         case typeKeyboard(keyboard: WordleKeyboard)
+    }
+
+    init(
+        gameRepository: GameRepositoryInterface,
+        gameObject: GameObject
+    ) {
+        self.gameRepository = gameRepository
+        self.gameObjcet = gameObject
     }
 
     func action(input: Input) {
@@ -88,7 +96,7 @@ final class WordleViewModel: ObservableObject {
 
         if currentIndex == wordleWordCount - 1 {
             let inputWord = wordle[triedWordleCount].compactMap { $0.alphabet }.map { String($0) }.joined()
-            guard !words.contains(inputWord) else {
+            guard !gameRepository.containsWord(word: inputWord) else {
                 canSubmitWordle = true
                 return
             }
@@ -122,7 +130,7 @@ final class WordleViewModel: ObservableObject {
               !wordle[triedWordleCount].contains(where: { $0.alphabet == nil })
         else { return }
         let submitWordle = wordle[triedWordleCount].compactMap { $0.alphabet }
-        let answerWordle = Array(answerWord.map { String($0) })
+        let answerWordle = Array(gameObjcet.gameAnswer.map { String($0) })
 
         for index in 0..<wordleWordCount {
             if submitWordle[index] == answerWordle[index] {
@@ -138,7 +146,7 @@ final class WordleViewModel: ObservableObject {
         }
         triedWordleCount += 1
 
-        if answerWord == submitWordle.joined() || triedWordleCount == 6 {
+        if gameObjcet.gameAnswer == submitWordle.joined() || triedWordleCount == 6 {
             isGameOver = true
             canSubmitWordle = false
         }
@@ -160,49 +168,3 @@ final class WordleViewModel: ObservableObject {
         }
     }
 }
-
-// TODO: Persistance 영역에 저장해놓기
-let words: [String] = [
-    "APPLE", "BRAVE", "CHARM", "DRINK", "EAGER",
-    "FABLE", "GLOBE", "HABIT", "IDEAL", "JOKER",
-    "KNEEL", "LUNCH", "MAGIC", "NOBLE", "OCEAN",
-    "PEACE", "QUEST", "RAVEN", "SPIKE", "TRUST",
-    "URBAN", "VIVID", "WITTY", "XENON", "YOUTH",
-    "ZEBRA", "ANGEL", "BEACH", "CHESS", "DOUGH",
-    "EXILE", "FLOCK", "GRACE", "HOVER", "IVORY",
-    "JOINT", "KNEES", "LIGHT", "MOTTO", "NOVEL",
-    "OLIVE", "PLACE", "QUIET", "REACT", "SALTY",
-    "THICK", "UPPER", "VALVE", "WHITE", "YIELD",
-    "ZESTY", "ARISE", "BLEND", "CRANE", "DAISY",
-    "EQUIP", "FEAST", "GROVE", "HEART", "INPUT",
-    "JOLLY", "KITTY", "LUCKY", "MINER", "NIFTY",
-    "OASIS", "PIANO", "QUILT", "RELAX", "SHORE",
-    "TOAST", "UMBRA", "VIGOR", "WHEAT", "XYLEM",
-    "ABIDE", "BLAME", "CROWN", "DANCE", "EAGLE",
-    "FIBER", "GRAPE", "HONEY", "INDEX", "JUMPY",
-    "KNIFE", "LOYAL", "MANGO", "NEEDY", "OVERT",
-    "PLAZA", "QUAKE", "RUMOR", "STONE", "TABLE",
-    "UPSET", "VOCAL", "WHIRL", "AMBER", "BIRTH",
-    "CABLE", "DONUT", "ELBOW", "FENCE", "GLIDE",
-    "HINGE", "INNER", "JEWEL", "LUNAR", "MEDAL",
-    "NURSE", "PENNY", "QUEEN", "RAZOR", "SHELL",
-    "TIGER", "UNDER", "VAPOR", "WHALE", "ARENA",
-    "BACON", "CHARM", "DOUBT", "EJECT", "FLOOD",
-    "GHOST", "HATCH", "IRONY", "JOLLY", "KNOCK",
-    "LEMON", "MERRY", "NORTH", "ORBIT", "PRIDE",
-    "QUARK", "ADORE", "BLOOM", "CRISP", "DEALT",
-    "EVENT", "FLAME", "GRAIN", "HARPY", "INPUT",
-    "JAZZY", "KARMA", "LODGE", "MIRTH", "ONION",
-    "PETTY", "QUICK", "RANCH", "STARK", "TIMID",
-    "UNITY", "WHISK", "ZONAL", "ACORN", "BREAD",
-    "CLIFF", "DWELL", "EXACT", "FLOAT", "GLOVE",
-    "HAPPY", "IDEAL", "JUICE", "KNACK", "LEAFY",
-    "MOTEL", "NAVEL", "OUTER", "PAINT", "QUIRK",
-    "REACT", "SPLIT", "TWIST", "UNITE", "VALUE",
-    "WASTE", "XERIC", "ZONED", "ALIVE", "BRISK",
-    "CRUSH", "DRILL", "EVERY", "FLARE", "GUEST",
-    "HOTEL", "IVORY", "JOKER", "KNELT", "LATCH",
-    "METAL", "NORTH", "OUTDO", "PLUMB", "QUERY",
-    "RHYME", "SPEAR", "TREND", "VAULT", "KOREA",
-    "MONTH", "ROUTE", "READY", "MONEY", "PEARL"
-]


### PR DESCRIPTION
## 🌁 Background
화이트보드에서 추가한 게임 오브젝트를 더블 클릭 시 워들 플레이할 수 있도록 구현하였습니다. 


## 📱 Screenshot
https://github.com/user-attachments/assets/cc163867-20f7-4239-ada5-9f28f14ec408


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- GameObjectView 더블탭 제스처 추가
- WhiteboardViewController와 WordleView 연동 


## ✅ Testing
화이트보드 내에서 게임 오브젝트 추가하여 Wordle을 플레이 해보세요 !


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- GameRepository에 게임 히스토리를 저장하고 불러오는 로직을 구현해놨습니다. 추후 개발하겠습니다.
- Wordle 랭킹도 추후 ...... 
- UIHostingController를 사용하여 SwiftUI 뷰와 연결해주었는데 그럼 이전 View에서 navigationBar가 히든 되는 현상 발생 ..  
viewWillAppear에서 navigationBar 보여주도록 하였습니다. 


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #27 
- close #54 
