### PR TITLE
[Fix] 라이트/다크 모드에 따른 그리기 색상 변경

### DIFF
--- a/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/DrawingView.swift
@@ -37,7 +37,7 @@ final class DrawingView: UIView {
 
     private func configureAttributes() {
         backgroundColor = .clear
-        drawingLayer.strokeColor = UIColor.black.cgColor
+        drawingLayer.strokeColor = UIColor.airplainBlack.cgColor
         drawingLayer.lineWidth = 5
         drawingLayer.lineCap = .round
         layer.addSublayer(drawingLayer)
@@ -46,6 +46,10 @@ final class DrawingView: UIView {
         drawingGesture.minimumNumberOfTouches = 1
         drawingGesture.maximumNumberOfTouches = 1
         self.addGestureRecognizer(drawingGesture)
+
+        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (drawingView: Self, _) in
+            drawingView.drawingLayer.strokeColor = UIColor.airplainBlack.cgColor
+        }
     }
 
     @objc private func handleDrawingGesture(sender: UIPanGestureRecognizer) {


### PR DESCRIPTION
## 🌁 Background
UIColor의 경우, dynamic color이기 때문에 라이트/다크 모드 전환에 따라 자동으로 색상이 변환됩니다.
UITraitCollection은 앱의 인터페이스에 대한 정보가 담겨있는데요, InterfaceStyle(다크모드인지, 라이트 모드인지)에 대한 정보도 확인할 수 있습니다.
유저가 InterfaceStyle를 바꾸면 UIKit이 알아서 저희가 미리 설정한 색을 찾아 바꿔주지만, UIKit 보다 low level인 CoreGraphic에서 사용하는 CGColor는 그렇지 않습니다. 따라서 iOS interface 환경이 바뀔때마다 호출되는 `traitCollectionDidChange` 를 오버라이딩 해서 직접 모드가 바뀔때마다 cgColor를 바꿔주고자 했습니다만,, iOS17 이후 Deprecated 되었다고 하는군요
![스크린샷 2024-11-30 오후 10 12 05](https://github.com/user-attachments/assets/c5c9dd97-f36e-4a04-b7f1-be7b5c537569)
![image](https://github.com/user-attachments/assets/33e97230-edad-488b-823f-c5631d04d606)

그리고 `UITraitChangeObservable`에 있는 `registerForTraitChanges` API를 사용하라고 합니다. `UIView`나 `UIViewController`가 이미 `UITraitChangeObservable` 를 채택하고 있기 때문에 따로 채택해주지는 않았고, `configureAttributes` 메서드 내에서 그림 그릴 때 사용하는 선의 색상을 설정해주었습니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 라이트/다크 모드 변화에 따라 그림 그리는 색상이 변하지 않는 문제 수정

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://eunjin3786.tistory.com/301
https://developer.apple.com/documentation/uikit/uitraitchangeobservable
https://stackoverflow.com/questions/77475103/traitcollectiondidchange-was-deprecated-in-ios-17-0-how-do-i-use-the-replacem