### PR TITLE
[Feature] 새로운 참여자 입장 시 Publishing 및 서칭 로직 통합

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -12,15 +12,12 @@ public protocol NearbyNetworkInterface {
     var reciptDataPublisher: AnyPublisher<Data, Never> { get }
     var reciptURLPublisher: AnyPublisher<(url: URL, dataInfo: DataInformationDTO), Never> { get }
     var connectionDelegate: NearbyNetworkConnectionDelegate? { get set }
-
-    /// 주변 기기를 검색합니다.
-    func startSearching()
-
+    
     /// 주변 기기 검색을 중지합니다.
     func stopSearching()
 
-    /// 주변 기기 검색을 중지 후 다시 시작합니다. 
-    func restartSearching()
+    /// 주변 기기를 검색합니다.
+    func startSearching()
 
     /// 주변에 내 기기를 정보와 함께 알립니다.
     /// - Parameter data: 담을 정보

--- a/DataSource/DataSource/Sources/Model/RequestedContext.swift
+++ b/DataSource/DataSource/Sources/Model/RequestedContext.swift
@@ -8,9 +8,11 @@
 import Foundation
 
 public struct RequestedContext: Codable {
+    let nickname: String
     let participant: String
 
-    public init(participant: String) {
+    public init(nickname: String, participant: String) {
+        self.nickname = nickname
         self.participant = participant
     }
 }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -5,22 +5,26 @@
 //  Created by 최다경 on 11/12/24.
 //
 
+import Combine
 import Domain
 import Foundation
 
 public final class WhiteboardRepository: WhiteboardRepositoryInterface {
-    private var nearbyNetwork: NearbyNetworkInterface
     public weak var delegate: WhiteboardRepositoryDelegate?
+    public let recentPeerPublisher: AnyPublisher<Profile, Never>
+    private var nearbyNetwork: NearbyNetworkInterface
     private var connections: [UUID: NetworkConnection]
     private var participantsInfo: [String: String]
     private let decoder = JSONDecoder()
     private var myProfile: Profile
+    private var recentPeerSubject = PassthroughSubject<Profile, Never>()
 
     public init(nearbyNetworkInterface: NearbyNetworkInterface, myProfile: Profile) {
         self.nearbyNetwork = nearbyNetworkInterface
         self.participantsInfo = [:]
         self.connections = [:]
         self.myProfile = myProfile
+        self.recentPeerPublisher = recentPeerSubject.eraseToAnyPublisher()
         self.nearbyNetwork.connectionDelegate = self
     }
 
@@ -51,7 +55,7 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
             name: whiteboard.name,
             info: participantsInfo)
 
-        let context = RequestedContext(participant: myProfile.profileIcon.emoji)
+        let context = RequestedContext(nickname: myProfile.nickname, participant: myProfile.profileIcon.emoji)
 
         try nearbyNetwork.joinConnection(connection: connection, context: context)
     }
@@ -139,10 +143,9 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
         with context: Data?,
         isHost: Bool
     ) {
-        if !isHost { return }
-
         do {
             guard
+                isHost,
                 let context = context,
                 let prevInfo = self.participantsInfo["participants"]
             else { return }
@@ -151,6 +154,14 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
             let invitationInfo = decodedContext.participant
             let currentInfo = prevInfo + "," + invitationInfo
             let requestedInfo = ["participants": invitationInfo]
+
+            guard let connectedPeerIcon = ProfileIcon(rawValue: invitationInfo) else { return }
+
+            let connectedPeer = Profile(
+                nickname: decodedContext.nickname,
+                profileIcon: connectedPeerIcon)
+
+            recentPeerSubject.send(connectedPeer)
 
             connections[connection.id] = NetworkConnection(id: connection.id, name: "", info: requestedInfo)
             updatePublishingInfo(myProfile: myProfile)

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -34,10 +34,6 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         nearbyNetwork.startPublishing(with: participantsInfo)
     }
 
-    public func startSearching() {
-        nearbyNetwork.startSearching()
-    }
-
     public func disconnectWhiteboard() {
         nearbyNetwork.disconnectAll()
         nearbyNetwork.stopPublishing()
@@ -64,8 +60,8 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         nearbyNetwork.stopSearching()
     }
 
-    public func restartSearching() {
-        nearbyNetwork.restartSearching()
+    public func startSearching() {
+        nearbyNetwork.startSearching()
     }
 
     private func updatePublishingInfo(myProfile: Profile) {

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -13,14 +13,11 @@ public protocol WhiteboardRepositoryInterface {
     /// - Parameter myProfile: 나의 프로필
     func startPublishing(myProfile: Profile)
 
-    /// 주변 화이트보드를 탐색합니다.
-    func startSearching()
-
     /// 화이트보드 탐색을 중지합니다.
     func stopSearching()
 
-    /// 화이트보드 탐색을 중단 후 다시 시작합니다. 
-    func restartSearching()
+    /// 화이트보드 탐색을 시작합니다. 
+    func startSearching()
 
     /// 화이트보드와 연결을 끊습니다. 
     func disconnectWhiteboard()

--- a/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
@@ -16,10 +16,7 @@ public protocol WhiteboardUseCaseInterface {
     /// 주변에 내 기기를 정보와 함께 알립니다.
     func startPublishingWhiteboard()
 
-    /// 주변 화이트보드를 탐색합니다.
-    func startSearchingWhiteboard()
-
-    /// 화이트보드와 연결을 끊습니다. 
+    /// 화이트보드와 연결을 끊습니다.
     func disconnectWhiteboard()
 
     /// 선택한 화이트보드와 연결을 시도합니다.
@@ -29,6 +26,6 @@ public protocol WhiteboardUseCaseInterface {
     /// 화이트보드 탐색을 중지합니다.
     func stopSearchingWhiteboard()
 
-    /// 화이트보드 탐색을 중단 후 다시 시작합니다. 
-    func refreshWhiteboardList()
+    /// 주변 화이트보드를 탐색합니다.
+    func startSearchingWhiteboards()
 }

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -38,10 +38,6 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
         whiteboardRepository.startPublishing(myProfile: myProfile)
     }
 
-    public func startSearchingWhiteboard() {
-        whiteboardRepository.startSearching()
-    }
-
     public func stopSearchingWhiteboard() {
         whiteboardRepository.stopSearching()
     }
@@ -55,8 +51,8 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
         try whiteboardRepository.joinWhiteboard(whiteboard: whiteboard, myProfile: profile)
     }
 
-    public func refreshWhiteboardList() {
-        whiteboardRepository.restartSearching()
+    public func startSearchingWhiteboards() {
+        whiteboardRepository.startSearching()
     }
 }
 

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -64,6 +64,7 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         serialQueue.sync {
             serviceBrowser.stopBrowsingForPeers()
             foundPeers.removeAll()
+            connectionDelegate?.nearbyNetwork(self, didFind: [])
             serviceBrowser.startBrowsingForPeers()
         }
     }

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -52,15 +52,11 @@ public final class NearbyNetworkService: NSObject {
 
 // MARK: - NearbyNetworkInterface
 extension NearbyNetworkService: NearbyNetworkInterface {
-    public func startSearching() {
-        serviceBrowser.startBrowsingForPeers()
-    }
-
     public func stopSearching() {
         serviceBrowser.stopBrowsingForPeers()
     }
 
-    public func restartSearching() {
+    public func startSearching() {
         serialQueue.sync {
             serviceBrowser.stopBrowsingForPeers()
             foundPeers.removeAll()

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -97,7 +97,7 @@ public final class WhiteboardListViewController: UIViewController {
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewModel.action(input: .searchWhiteboard)
+        viewModel.action(input: .startSearchingWhiteboards)
     }
 
     public override func viewDidDisappear(_ animated: Bool) {
@@ -267,7 +267,7 @@ public final class WhiteboardListViewController: UIViewController {
     }
 
     private func refreshWhiteboardList() {
-        viewModel.action(input: .refreshWhiteboardList)
+        viewModel.action(input: .startSearchingWhiteboards)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.refreshControl.endRefreshing()
         }

--- a/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/ViewModel/WhiteboardListViewModel.swift
@@ -15,10 +15,9 @@ public final class WhiteboardListViewModel: ViewModel {
 
     enum Input {
         case createWhiteboard
-        case searchWhiteboard
         case joinWhiteboard(whiteboard: Whiteboard)
         case stopSearchingWhiteboard
-        case refreshWhiteboardList
+        case startSearchingWhiteboards
     }
 
     struct Output {
@@ -39,13 +38,11 @@ public final class WhiteboardListViewModel: ViewModel {
         switch input {
         case .createWhiteboard:
             createWhiteboard()
-        case .searchWhiteboard:
-            searchWhiteboard()
         case .joinWhiteboard(let whiteboard):
             joinWhiteboard(whiteboard: whiteboard)
         case .stopSearchingWhiteboard:
             stopSearchingWhiteboard()
-        case .refreshWhiteboardList:
+        case .startSearchingWhiteboards:
             refreshWhiteboardList()
         }
     }
@@ -54,10 +51,6 @@ public final class WhiteboardListViewModel: ViewModel {
         let whiteboard = whiteboardUseCase.createWhiteboard()
         whiteboardUseCase.startPublishingWhiteboard()
         whiteboardSubject.send(whiteboard)
-    }
-
-    private func searchWhiteboard() {
-        whiteboardUseCase.startSearchingWhiteboard()
     }
 
     private func joinWhiteboard(whiteboard: Whiteboard) {
@@ -73,6 +66,6 @@ public final class WhiteboardListViewModel: ViewModel {
     }
 
     private func refreshWhiteboardList() {
-        whiteboardUseCase.refreshWhiteboardList()
+        whiteboardUseCase.startSearchingWhiteboards()
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 새로운 참여자 입장 시 호스트가 기존 `Object`들을 모두 보내주기 위해 참여자의 `Profile`을 `Publishing` 합니다. 
    - `WhiteboardRepository`의 `recentPeerPublisher`에서 값을 `publishing` 합니다. 
- 새로고침을 해도 사라진 보드가 남아있던 버그를 수정했습니다. 
- 서칭 로직을 통합했습니다. 

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/eccef189-9680-4287-8c3e-c0bf2d86b442

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 새로운 참여자 입장 시 해당 참여자 Profile publishing
- 새로고침 해도 사라진 보드가 보이는 버그 픽스
- 서칭 로직 통합

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
시뮬레이터 실행 시 테스트 가능합니다. 
로직과 관련된 테스트 상황
1. 호스트가 보드에 새로운 참여자가 생겨 다시 퍼블리싱 했을 때 브라우저가 새로고침 하는 상황
2. 참여자가 뒤로가기 버튼을 눌러 `WhiteboardListViewController`로 나온 상황

위 두가지 상황에서 최신의 보드 리스트를 제공합니다. 

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
현재 `WhiteboardRepository`에서 해서는 안될 로직까지 처리하고있습니다.
설계할 때 미처 생각하지 못했습니다. 
리팩토링 기간 때 개선해보겠습니다. 
죄송합니다. 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #11 
- close #20 
