### PR TITLE
[Feature] 화이트보드 접속 시, 화이트 보드 데이터를 받아오는 기능 구현

### DIFF
--- a/AirplaIN/AirplaIN/SceneDelegate.swift
+++ b/AirplaIN/AirplaIN/SceneDelegate.swift
@@ -45,7 +45,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let profileUseCase = ProfileUseCase(repository: profileRepository)
         let manageWhieboardObjectUseCase = ManageWhiteboardObjectUseCase(
             profileRepository: profileRepository,
-            whiteboardRepository: whiteboardObjectRepository,
+            whiteboardObjectRepository: whiteboardObjectRepository,
+            whiteboardRepository: whiteboardRepository,
             whiteboardObjectSet: whiteboardObjectSet)
         let manageWhiteboardToolUseCase = ManageWhiteboardToolUseCase()
         let textObjectUseCase = TextObjectUseCase(
@@ -53,7 +54,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             textFieldDefaultSize: CGSize(width: 200, height: 50))
         let drawObjectUseCase = DrawObjectUseCase()
         let gameObjectUseCase = GameObjectUseCase(repository: GameRepository(persistenceService: PersistenceService()))
-        let addPhotoUseCase = AddPhotoUseCase(photoRepository: photoRepository)
+        let addPhotoUseCase = PhotoUseCase(photoRepository: photoRepository)
         let chatUseCase = ChatUseCase(chatRepository: chatRepository)
 
         let whiteboardObjectViewFactory = WhiteboardObjectViewFactory()

--- a/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/FilePersistenceInterface.swift
@@ -22,4 +22,9 @@ public protocol FilePersistenceInterface {
     /// - Parameter path: 가져올 데이터의 위치를 URL로 받습니다.
     /// - Returns: 해당 위치에 존재하는 데이터를 가져옵니다.
     func load(path: URL) -> Data?
+
+    /// 데이터가 저장되어 있다면, 저장되어 있는 URL을 반환합니다.
+    /// - Parameter dataInfo: 저장한 데이터의 정보
+    /// - Returns: 데이터의 저장 위치
+    func fetchURL(dataInfo: DataInformationDTO) -> URL?
 }

--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -42,6 +42,16 @@ public protocol NearbyNetworkInterface {
     ///   - fileURL: 파일의 URL
     ///   - info: 파일에 대한 정보
     func send(fileURL: URL, info: DataInformationDTO) async
+    
+    /// 특정 기기에게 파일을 전송합니다.
+    /// - Parameters:
+    ///   - fileURL: 파일의 URL
+    ///   - info: 파일에 대한 정보
+    ///   - connection: 전송할 기기 연결 정보
+    func send(
+        fileURL: URL,
+        info: DataSource.DataInformationDTO,
+        to connection: NetworkConnection) async
 }
 
 public protocol NearbyNetworkConnectionDelegate: AnyObject {

--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -42,7 +42,7 @@ public protocol NearbyNetworkInterface {
     ///   - fileURL: 파일의 URL
     ///   - info: 파일에 대한 정보
     func send(fileURL: URL, info: DataInformationDTO) async
-    
+
     /// 특정 기기에게 파일을 전송합니다.
     /// - Parameters:
     ///   - fileURL: 파일의 URL

--- a/DataSource/DataSource/Sources/Repository/PhotoRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/PhotoRepository.swift
@@ -21,7 +21,21 @@ public final class PhotoRepository: PhotoRepositoryInterface {
             type: .imageData,
             isDeleted: false)
 
-        let photoURL = filePersistence.save(dataInfo: dataInformation, data: imageData)
-        return photoURL
+        let imageURL = filePersistence.save(dataInfo: dataInformation, data: imageData)
+        return imageURL
+    }
+
+    public func fetchPhoto(id: UUID) -> Data? {
+        let dataInformation = DataInformationDTO(
+            id: id,
+            type: .imageData,
+            isDeleted: false)
+
+        guard
+            let imageURL = filePersistence.fetchURL(dataInfo: dataInformation),
+            let imageData = filePersistence.load(path: imageURL)
+        else { return nil }
+
+        return imageData
     }
 }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -51,7 +51,7 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
                 taskGroup.addTask {
                     await self.send(
                         whiteboardObject: object,
-                        isDeleted: false,
+                        isDeleted: isDeleted,
                         profile: profile)
                 }
             }

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -24,7 +24,7 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
     }
 
     public func send(
-        whiteboardObject: Domain.WhiteboardObject,
+        whiteboardObject: WhiteboardObject,
         isDeleted: Bool,
         to profile: Profile
     ) async {

--- a/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardObjectRepository.swift
@@ -23,47 +23,70 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
         bindNearbyNetwork()
     }
 
+    public func send(
+        whiteboardObject: Domain.WhiteboardObject,
+        isDeleted: Bool,
+        to profile: Profile
+    ) async {
+        await send(
+            whiteboardObject: whiteboardObject,
+            isDeleted: isDeleted,
+            profile: profile)
+    }
+
     public func send(whiteboardObject: WhiteboardObject, isDeleted: Bool) async {
-        switch whiteboardObject {
-        case let textObject as TextObject:
-            await send(
-                whiteboardObject: textObject,
-                type: .text,
-                isDeleted: isDeleted)
-        case let drawingObject as DrawingObject:
-            await send(
-                whiteboardObject: drawingObject,
-                type: .drawing,
-                isDeleted: isDeleted)
-        case let photoObject as PhotoObject:
-            await send(
-                whiteboardObject: photoObject,
-                type: .photo,
-                isDeleted: isDeleted)
-            await sendJPEG(
-                photoObject: photoObject,
-                type: .imageData,
-                isDeleted: isDeleted)
-        case let gameObject as GameObject:
-            await send(
-                whiteboardObject: gameObject,
-                type: .game,
-                isDeleted: isDeleted)
-        default:
-            break
+        await send(
+            whiteboardObject: whiteboardObject,
+            isDeleted: isDeleted,
+            profile: nil)
+    }
+
+    public func send(
+        whiteboardObjects: [WhiteboardObject],
+        isDeleted: Bool,
+        to profile: Profile
+    ) async {
+        await withTaskGroup(of: Void.self) { taskGroup in
+            whiteboardObjects.forEach { object in
+                taskGroup.addTask {
+                    await self.send(
+                        whiteboardObject: object,
+                        isDeleted: false,
+                        profile: profile)
+                }
+            }
         }
     }
 
     private func send(
         whiteboardObject: WhiteboardObject,
-        type: AirplaINDataType,
-        isDeleted: Bool
+        isDeleted: Bool,
+        profile: Profile?
     ) async {
+        let type: AirplaINDataType?
         let objectData = try? JSONEncoder().encode(whiteboardObject)
+
+        switch whiteboardObject {
+        case _ as TextObject:
+            type = .text
+        case _ as DrawingObject:
+            type = .drawing
+        case let photoObject as PhotoObject:
+            await sendJPEG(photoID: photoObject.id, isDeleted: isDeleted)
+            type = .photo
+        case _ as GameObject:
+            type = .game
+        default:
+            type = nil
+        }
+
+        guard let type else { return }
+
         let objectInformation = DataInformationDTO(
             id: whiteboardObject.id,
             type: type,
             isDeleted: isDeleted)
+
         guard let url = filePersistence
             .save(dataInfo: objectInformation, data: objectData)
         else {
@@ -74,16 +97,15 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
     }
 
     // TODO: - 사진 데이터를 photo Object와 따로 보내야함! 추후 전송 방식 개선하기
-    private func sendJPEG(
-        photoObject: PhotoObject,
-        type: AirplaINDataType,
-        isDeleted: Bool
-    ) async {
+    private func sendJPEG(photoID: UUID, isDeleted: Bool) async {
         let dataInformation = DataInformationDTO(
-            id: photoObject.id,
+            id: photoID,
             type: .imageData,
             isDeleted: isDeleted)
-        await nearbyNetwork.send(fileURL: photoObject.photoURL, info: dataInformation)
+
+        guard let photoURL = filePersistence.fetchURL(dataInfo: dataInformation) else { return }
+
+        await nearbyNetwork.send(fileURL: photoURL, info: dataInformation)
     }
 
     private func bindNearbyNetwork() {
@@ -102,8 +124,10 @@ public final class WhiteboardObjectRepository: WhiteboardObjectRepositoryInterfa
     }
 
     private func handlePhotoData(didReceiveURL URL: URL, info: DataInformationDTO) {
-        guard let receiveData = filePersistence.load(path: URL) else { return }
-        guard let savedURL = filePersistence.save(dataInfo: info, data: receiveData) else { return }
+        guard
+            let receiveData = filePersistence.load(path: URL),
+            let savedURL = filePersistence.save(dataInfo: info, data: receiveData)
+        else { return }
 
         if !info.isDeleted {
             delegate?.whiteboardObjectRepository(

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -47,7 +47,7 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         let participantsInfo = ["participants": profileIcons]
 
         let connection = NetworkConnection(
-            id: whiteboard.ID,
+            id: whiteboard.id,
             name: whiteboard.name,
             info: participantsInfo)
 
@@ -148,7 +148,6 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
 
             let decodedContext = try JSONDecoder().decode(RequestedContext.self, from: context)
             let invitationInfo = decodedContext.participant
-            let currentInfo = prevInfo + "," + invitationInfo
             let requestedInfo = ["participants": invitationInfo]
 
             guard let connectedProfileIcon = ProfileIcon(rawValue: invitationInfo) else { return }
@@ -174,12 +173,6 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
         isHost: Bool
     ) {
         if !isHost { return }
-        guard
-            let prevInfo = self.participantsInfo["participants"],
-            let lostConnection = connections[connection.id],
-            let lostInfo = lostConnection.info,
-            let lostIcon = lostInfo["participants"]
-        else { return }
 
         connections[connection.id] = nil
         updatePublishingInfo(myProfile: myProfile)

--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -151,13 +151,14 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
             let currentInfo = prevInfo + "," + invitationInfo
             let requestedInfo = ["participants": invitationInfo]
 
-            guard let connectedPeerIcon = ProfileIcon(rawValue: invitationInfo) else { return }
+            guard let connectedProfileIcon = ProfileIcon(rawValue: invitationInfo) else { return }
 
-            let connectedPeer = Profile(
+            let connectedProfile = Profile(
+                id: connection.id,
                 nickname: decodedContext.nickname,
-                profileIcon: connectedPeerIcon)
+                profileIcon: connectedProfileIcon)
 
-            recentPeerSubject.send(connectedPeer)
+            recentPeerSubject.send(connectedProfile)
 
             connections[connection.id] = NetworkConnection(id: connection.id, name: "", info: requestedInfo)
             updatePublishingInfo(myProfile: myProfile)

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		00036B822CF56414007D1244 /* PhotoRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */; };
 		00036B862CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00036B852CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift */; };
 		003D5A2B2CEB1FF0005F3D09 /* PhotoObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2A2CEB1FEA005F3D09 /* PhotoObject.swift */; };
-		003D5A2D2CEB21AA005F3D09 /* AddPhotoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */; };
-		003D5A2F2CEB21B6005F3D09 /* AddPhotoUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */; };
+		003D5A2D2CEB21AA005F3D09 /* PhotoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2C2CEB217E005F3D09 /* PhotoUseCase.swift */; };
+		003D5A2F2CEB21B6005F3D09 /* PhotoUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003D5A2E2CEB21B2005F3D09 /* PhotoUseCaseInterface.swift */; };
 		004B217D2CEB2B2300A5BEB8 /* DomainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004B217C2CEB2B2300A5BEB8 /* DomainError.swift */; };
 		005BCC512CF01D29001B3623 /* WhiteboardObjectSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005BCC502CF01D29001B3623 /* WhiteboardObjectSet.swift */; };
 		00683D692CE37F2F000D28E4 /* DrawingObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00683D682CE37F2F000D28E4 /* DrawingObject.swift */; };
@@ -83,8 +83,8 @@
 		00036B812CF56414007D1244 /* PhotoRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRepositoryInterface.swift; sourceTree = "<group>"; };
 		00036B852CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectSetInterface.swift; sourceTree = "<group>"; };
 		003D5A2A2CEB1FEA005F3D09 /* PhotoObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoObject.swift; sourceTree = "<group>"; };
-		003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoUseCase.swift; sourceTree = "<group>"; };
-		003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPhotoUseCaseInterface.swift; sourceTree = "<group>"; };
+		003D5A2C2CEB217E005F3D09 /* PhotoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoUseCase.swift; sourceTree = "<group>"; };
+		003D5A2E2CEB21B2005F3D09 /* PhotoUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoUseCaseInterface.swift; sourceTree = "<group>"; };
 		004B217C2CEB2B2300A5BEB8 /* DomainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainError.swift; sourceTree = "<group>"; };
 		005BCC502CF01D29001B3623 /* WhiteboardObjectSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectSet.swift; sourceTree = "<group>"; };
 		00683D682CE37F2F000D28E4 /* DrawingObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingObject.swift; sourceTree = "<group>"; };
@@ -165,7 +165,7 @@
 				5BDFD9392CE2EE3100DA4F5B /* WhiteboardUseCase.swift */,
 				00D2DD852CE887540089F0BA /* ManageWhiteboardObjectUseCase.swift */,
 				00D2DD902CE88D260089F0BA /* ManageWhiteboardToolUseCase.swift */,
-				003D5A2C2CEB217E005F3D09 /* AddPhotoUseCase.swift */,
+				003D5A2C2CEB217E005F3D09 /* PhotoUseCase.swift */,
 				6F3BCDCF2CF3322C005F6642 /* ChatUseCase.swift */,
 				A81E7BF82CF72503007E8414 /* GameObjectUseCase.swift */,
 			);
@@ -240,7 +240,7 @@
 				5B6542472CE44631000168AD /* WhiteboardUseCaseInterface.swift */,
 				00D2DD832CE8864B0089F0BA /* ManageWhiteboardObjectUseCaseInterface.swift */,
 				00D2DD872CE88BD80089F0BA /* ManageWhiteboardToolUseCaseInterface.swift */,
-				003D5A2E2CEB21B2005F3D09 /* AddPhotoUseCaseInterface.swift */,
+				003D5A2E2CEB21B2005F3D09 /* PhotoUseCaseInterface.swift */,
 				6F3BCDCD2CF3312A005F6642 /* ChatUseCaseInterface.swift */,
 				A81E7BFA2CF725C2007E8414 /* GameObjectUseCaseInterface.swift */,
 			);
@@ -448,7 +448,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				003D5A2F2CEB21B6005F3D09 /* AddPhotoUseCaseInterface.swift in Sources */,
+				003D5A2F2CEB21B6005F3D09 /* PhotoUseCaseInterface.swift in Sources */,
 				A8E97C052CE5E3AB00B28063 /* ProfileUseCaseInterface.swift in Sources */,
 				004B217D2CEB2B2300A5BEB8 /* DomainError.swift in Sources */,
 				6F3BCDC82CF31CB4005F6642 /* ChatMessage.swift in Sources */,
@@ -481,7 +481,7 @@
 				00683D722CE3A74A000D28E4 /* DrawObjectUseCase.swift in Sources */,
 				00D2DD8F2CE88C640089F0BA /* WhiteboardTool.swift in Sources */,
 				0080E91A2CE4B0880095B958 /* DrawObjectUseCaseInterface.swift in Sources */,
-				003D5A2D2CEB21AA005F3D09 /* AddPhotoUseCase.swift in Sources */,
+				003D5A2D2CEB21AA005F3D09 /* PhotoUseCase.swift in Sources */,
 				00D2DD912CE88D260089F0BA /* ManageWhiteboardToolUseCase.swift in Sources */,
 				00D2DD862CE887540089F0BA /* ManageWhiteboardObjectUseCase.swift in Sources */,
 				00683D692CE37F2F000D28E4 /* DrawingObject.swift in Sources */,

--- a/Domain/Domain/Sources/Entity/PhotoObject.swift
+++ b/Domain/Domain/Sources/Entity/PhotoObject.swift
@@ -8,10 +8,6 @@
 import Foundation
 
 public final class PhotoObject: WhiteboardObject {
-    public private(set) var photoURL: URL
-
-    private enum CodingKeys: String, CodingKey { case photoURL }
-
     public init(
         id: UUID,
         centerPosition: CGPoint,
@@ -21,7 +17,6 @@ public final class PhotoObject: WhiteboardObject {
         photoURL: URL,
         selectedBy: Profile? = nil
     ) {
-        self.photoURL = photoURL
         super.init(
             id: id,
             centerPosition: centerPosition,
@@ -32,19 +27,6 @@ public final class PhotoObject: WhiteboardObject {
     }
 
     required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let photoURL = try container.decode(URL.self, forKey: .photoURL)
-        self.photoURL = photoURL
         try super.init(from: decoder)
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(photoURL, forKey: .photoURL)
-        try super.encode(to: encoder)
-    }
-
-    func configurePhotoURL(with URL: URL) {
-        photoURL = URL
     }
 }

--- a/Domain/Domain/Sources/Entity/PhotoObject.swift
+++ b/Domain/Domain/Sources/Entity/PhotoObject.swift
@@ -8,25 +8,5 @@
 import Foundation
 
 public final class PhotoObject: WhiteboardObject {
-    public init(
-        id: UUID,
-        centerPosition: CGPoint,
-        size: CGSize,
-        scale: CGFloat = 1,
-        angle: CGFloat = 0,
-        photoURL: URL,
-        selectedBy: Profile? = nil
-    ) {
-        super.init(
-            id: id,
-            centerPosition: centerPosition,
-            size: size,
-            scale: scale,
-            angle: angle,
-            selectedBy: selectedBy)
-    }
 
-    required init(from decoder: Decoder) throws {
-        try super.init(from: decoder)
-    }
 }

--- a/Domain/Domain/Sources/Entity/Profile.swift
+++ b/Domain/Domain/Sources/Entity/Profile.swift
@@ -12,10 +12,21 @@ public struct Profile: Codable, Hashable {
     public let nickname: String
     public let profileIcon: ProfileIcon
 
-    public init(nickname: String, profileIcon: ProfileIcon) {
-        id = UUID()
+    public init(
+        id: UUID,
+        nickname: String,
+        profileIcon: ProfileIcon
+    ) {
+        self.id = id
         self.nickname = nickname
         self.profileIcon = profileIcon
+    }
+
+    public init(nickname: String, profileIcon: ProfileIcon) {
+        self.init(
+            id: UUID(),
+            nickname: nickname,
+            profileIcon: profileIcon)
     }
 }
 

--- a/Domain/Domain/Sources/Entity/Whiteboard.swift
+++ b/Domain/Domain/Sources/Entity/Whiteboard.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 public struct Whiteboard: Hashable {
-    public let ID: UUID
+    public let id: UUID
     public let name: String
     public let participantIcons: [ProfileIcon]
 
@@ -20,13 +20,13 @@ public struct Whiteboard: Hashable {
         participantIcons: [ProfileIcon],
         objects: [WhiteboardObject] = []
     ) {
-        self.ID = id
+        self.id = id
         self.name = name
         self.participantIcons = participantIcons
         self.objects = objects
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(ID)
+        hasher.combine(id)
     }
 }

--- a/Domain/Domain/Sources/Interface/Repository/PhotoRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/PhotoRepositoryInterface.swift
@@ -14,4 +14,9 @@ public protocol PhotoRepositoryInterface {
     ///  imageData: 사진 이미지 데이터
     /// - Returns: 저장한 위치 URL
     func savePhoto(id: UUID, imageData: Data) -> URL?
+
+    /// 저장된 사진을 가져옵니다
+    /// - Parameter id: 사진의 id
+    /// - Returns: 사진 데이터
+    func fetchPhoto(id: UUID) -> Data?
 }

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -9,7 +9,7 @@ import Foundation
 public protocol WhiteboardObjectRepositoryInterface {
     /// WhiteboardObjectRepository의 delegate
     var delegate: WhiteboardObjectRepositoryDelegate? { get set }
-    
+
     /// 특정 사람에게 화이트보드 오브젝트를 전송하는 메서드
     /// - Parameters:
     ///   - whiteboardObject: 전송할 화이트보드 오브젝트
@@ -23,7 +23,7 @@ public protocol WhiteboardObjectRepositoryInterface {
     /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
     /// - Parameter whiteboardObject: 전송할 Whiteboard Object
     func send(whiteboardObject: WhiteboardObject, isDeleted: Bool) async
-    
+
     /// 특정 사람에게 화이트보드 오브젝트 배열을 전송하는 메서드
     /// - Parameters:
     ///   - whiteboardObjects: 전송할 화이트보드 오브젝트들
@@ -32,8 +32,7 @@ public protocol WhiteboardObjectRepositoryInterface {
     func send(
         whiteboardObjects: [WhiteboardObject],
         isDeleted: Bool,
-        to profile: Profile
-    ) async
+        to profile: Profile) async
 }
 
 public protocol WhiteboardObjectRepositoryDelegate: AnyObject {

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardObjectRepositoryInterface.swift
@@ -9,10 +9,31 @@ import Foundation
 public protocol WhiteboardObjectRepositoryInterface {
     /// WhiteboardObjectRepository의 delegate
     var delegate: WhiteboardObjectRepositoryDelegate? { get set }
+    
+    /// 특정 사람에게 화이트보드 오브젝트를 전송하는 메서드
+    /// - Parameters:
+    ///   - whiteboardObject: 전송할 화이트보드 오브젝트
+    ///   - isDeleted: 오브젝트 삭제 여부
+    ///   - profile: 전송할 사람
+    func send(
+        whiteboardObject: WhiteboardObject,
+        isDeleted: Bool,
+        to profile: Profile) async
 
     /// 다른 사람들에게 화이트보드 오브젝트를 전송하는 메서드.
     /// - Parameter whiteboardObject: 전송할 Whiteboard Object
     func send(whiteboardObject: WhiteboardObject, isDeleted: Bool) async
+    
+    /// 특정 사람에게 화이트보드 오브젝트 배열을 전송하는 메서드
+    /// - Parameters:
+    ///   - whiteboardObjects: 전송할 화이트보드 오브젝트들
+    ///   - isDeleted: 오브젝트 삭제 여부
+    ///   - profile: 전송할 사람
+    func send(
+        whiteboardObjects: [WhiteboardObject],
+        isDeleted: Bool,
+        to profile: Profile
+    ) async
 }
 
 public protocol WhiteboardObjectRepositoryDelegate: AnyObject {

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -4,10 +4,12 @@
 //
 //  Created by 최다경 on 11/12/24.
 //
+import Combine
 import Foundation
 
 public protocol WhiteboardRepositoryInterface {
     var delegate: WhiteboardRepositoryDelegate? { get set }
+    var recentPeerPublisher: AnyPublisher<Profile, Never> { get }
 
     /// 주변에 내 기기를 참여자의 아이콘 정보와 함께 화이트보드를 알립니다.
     /// - Parameter myProfile: 나의 프로필

--- a/Domain/Domain/Sources/Interface/UseCase/PhotoUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/PhotoUseCaseInterface.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-public protocol AddPhotoUseCaseInterface {
-
+public protocol PhotoUseCaseInterface {
     /// 사진 오브젝트를 추가합니다.
     /// - Parameters:
     ///   - imageData: 추가할 사진의 데이터
@@ -20,4 +19,9 @@ public protocol AddPhotoUseCaseInterface {
         centerPosition: CGPoint,
         size: CGSize
     ) -> PhotoObject?
+
+    /// 사진을 가져옵니다.
+    /// - Parameter imageID: 가져올 사진 id
+    /// - Returns: 사진 바이너리 데이터
+    func fetchPhoto(imageID: UUID) -> Data?
 }

--- a/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
+++ b/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
@@ -30,4 +30,8 @@ public protocol WhiteboardObjectSetInterface {
     /// - Parameter id: 가져올 오브젝트의 ID
     /// - Returns: 오브젝트
     func fetchObjectByID(id: UUID) async -> WhiteboardObject?
+
+    /// 모든 화이트보드 오브젝트들을 가져옵니다.
+    /// - Returns: 화이트보드 오브젝트 배열
+    func fetchAll() async -> [WhiteboardObject]
 }

--- a/Domain/Domain/Sources/Model/WhiteboardObjectSet.swift
+++ b/Domain/Domain/Sources/Model/WhiteboardObjectSet.swift
@@ -34,4 +34,8 @@ public actor WhiteboardObjectSet: WhiteboardObjectSetInterface {
     public func fetchObjectByID(id: UUID) -> WhiteboardObject? {
         return whiteboardObjects.first { $0.id == id }
     }
+
+    public func fetchAll() async -> [WhiteboardObject] {
+        return Array(whiteboardObjects.sorted { $0.updatedAt < $1.updatedAt })
+    }
 }

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -163,10 +163,10 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
     private func sendAllWhiteboardObjects(to profile: Profile) {
         Task {
             let objects = await self.whiteboardObjectSet.fetchAll()
-            let chunckedObjects = stride(from: 0, to: objects.count, by: 10).map {
-                Array(objects[$0..<min($0 + 10, objects.count)])
+            let chunckedObjects = stride(from: 0, to: objects.count, by: 5).map {
+                Array(objects[$0..<min($0 + 5, objects.count)])
             }
-            
+
             for chuncked in chunckedObjects {
                 await whiteboardObjectRepository.send(
                     whiteboardObjects: chuncked,

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -14,18 +14,20 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
     public var removedObjectPublisher: AnyPublisher<WhiteboardObject, Never>
     public var selectedObjectIDPublisher: AnyPublisher<UUID?, Never>
 
-    private var whiteboardObjectSet: WhiteboardObjectSetInterface
-
     private let addedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
     private let updatedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
     private let removedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
     private let selectedObjectIDSubject: CurrentValueSubject<UUID?, Never>
-    private var whiteboardObjectRepository: WhiteboardObjectRepositoryInterface
+    private let whiteboardRepository: WhiteboardRepositoryInterface
     private let myProfile: Profile
+    private var whiteboardObjectRepository: WhiteboardObjectRepositoryInterface
+    private var whiteboardObjectSet: WhiteboardObjectSetInterface
+    private var cancellables: Set<AnyCancellable>
 
     public init(
         profileRepository: ProfileRepositoryInterface,
-        whiteboardRepository: WhiteboardObjectRepositoryInterface,
+        whiteboardObjectRepository: WhiteboardObjectRepositoryInterface,
+        whiteboardRepository: WhiteboardRepositoryInterface,
         whiteboardObjectSet: WhiteboardObjectSetInterface
     ) {
         addedWhiteboardSubject = PassthroughSubject<WhiteboardObject, Never>()
@@ -39,9 +41,13 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         selectedObjectIDPublisher = selectedObjectIDSubject.eraseToAnyPublisher()
 
         self.whiteboardObjectSet = whiteboardObjectSet
+        self.whiteboardObjectRepository = whiteboardObjectRepository
+        self.whiteboardRepository = whiteboardRepository
         myProfile = profileRepository.loadProfile()
-        self.whiteboardObjectRepository = whiteboardRepository
-        whiteboardObjectRepository.delegate = self
+        cancellables = []
+        self.whiteboardObjectRepository.delegate = self
+
+        bindWhiteboardRepository()
     }
 
     @discardableResult
@@ -145,6 +151,30 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         object.changePosition(position: position)
         return await updateObject(whiteboardObject: object, isReceivedObject: false)
     }
+
+    private func bindWhiteboardRepository() {
+        whiteboardRepository.recentPeerPublisher
+            .sink { [weak self] profile in
+                self?.sendAllWhiteboardObjects(to: profile)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func sendAllWhiteboardObjects(to profile: Profile) {
+        Task {
+            let objects = await self.whiteboardObjectSet.fetchAll()
+            let chunckedObjects = stride(from: 0, to: objects.count, by: 10).map {
+                Array(objects[$0..<min($0 + 10, objects.count)])
+            }
+            
+            for chuncked in chunckedObjects {
+                await whiteboardObjectRepository.send(
+                    whiteboardObjects: chuncked,
+                    isDeleted: false,
+                    to: profile)
+            }
+        }
+    }
 }
 
 extension ManageWhiteboardObjectUseCase: WhiteboardObjectRepositoryDelegate {
@@ -158,7 +188,7 @@ extension ManageWhiteboardObjectUseCase: WhiteboardObjectRepositoryDelegate {
                 let photoObject = await whiteboardObjectSet
                     .fetchObjectByID(id: photoID) as? PhotoObject
             else { return }
-            photoObject.configurePhotoURL(with: savedURL)
+
             await updateObject(whiteboardObject: photoObject, isReceivedObject: true)
         }
     }

--- a/Domain/Domain/Sources/UseCase/PhotoUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/PhotoUseCase.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class AddPhotoUseCase: AddPhotoUseCaseInterface {
+public final class PhotoUseCase: PhotoUseCaseInterface {
     private let photoRepository: PhotoRepositoryInterface
 
     public init(photoRepository: PhotoRepositoryInterface) {
@@ -35,5 +35,9 @@ public final class AddPhotoUseCase: AddPhotoUseCaseInterface {
             photoURL: photoURL)
 
         return photoObject
+    }
+
+    public func fetchPhoto(imageID: UUID) -> Data? {
+        photoRepository.fetchPhoto(id: imageID)
     }
 }

--- a/Domain/Domain/Sources/UseCase/PhotoUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/PhotoUseCase.swift
@@ -20,8 +20,6 @@ public final class PhotoUseCase: PhotoUseCaseInterface {
         size: CGSize
     ) -> PhotoObject? {
         let id = UUID()
-        let photoURL = photoRepository.savePhoto(id: id, imageData: imageData)
-        guard let photoURL else { return nil }
 
         var size = size
         let scaleFactor = size.width >= size.height ? 200 / size.width : 200 / size.height
@@ -31,8 +29,7 @@ public final class PhotoUseCase: PhotoUseCaseInterface {
         let photoObject = PhotoObject(
             id: id,
             centerPosition: centerPosition,
-            size: size,
-            photoURL: photoURL)
+            size: size)
 
         return photoObject
     }

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -67,7 +67,7 @@ extension WhiteboardUseCase: WhiteboardRepositoryDelegate {
     public func whiteboardRepository(_ sender: any WhiteboardRepositoryInterface, didLost whiteboardId: UUID) {
         let updatedWhiteboards = whiteboardListSubject
             .value
-            .filter { $0.ID != whiteboardId }
+            .filter { $0.id != whiteboardId }
         whiteboardListSubject.send(updatedWhiteboards)
     }
 }

--- a/Domain/DomainTests/AddPhotoUseCaseTests.swift
+++ b/Domain/DomainTests/AddPhotoUseCaseTests.swift
@@ -12,7 +12,7 @@ final class MockPhotoRepository: PhotoRepositoryInterface {
     func fetchPhoto(id: UUID) -> Data? {
         return Data()
     }
-    
+
     func savePhoto(id: UUID, imageData: Data) -> URL? {
         return URL(filePath: "photo.jpg")
     }

--- a/Domain/DomainTests/AddPhotoUseCaseTests.swift
+++ b/Domain/DomainTests/AddPhotoUseCaseTests.swift
@@ -9,18 +9,22 @@ import Domain
 import XCTest
 
 final class MockPhotoRepository: PhotoRepositoryInterface {
+    func fetchPhoto(id: UUID) -> Data? {
+        return Data()
+    }
+    
     func savePhoto(id: UUID, imageData: Data) -> URL? {
         return URL(filePath: "photo.jpg")
     }
 }
 
 final class AddPhotoUseCaseTests: XCTestCase {
-    private var useCase: AddPhotoUseCase!
+    private var useCase: PhotoUseCase!
 
     override func setUp() {
         super.setUp()
         let mockPhotoRepository = MockPhotoRepository()
-        useCase =  AddPhotoUseCase(photoRepository: mockPhotoRepository)
+        useCase =  PhotoUseCase(photoRepository: mockPhotoRepository)
     }
 
     override func tearDown() {

--- a/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
+++ b/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
@@ -20,7 +20,8 @@ final class ManageWhiteboardObjectsUseCaseTests: XCTestCase {
 
         useCase = ManageWhiteboardObjectUseCase(
             profileRepository: profileRepository,
-            whiteboardRepository: MockWhiteObjectRepository(),
+            whiteboardObjectRepository: MockWhiteObjectRepository(),
+            whiteboardRepository: MockWhiteboardRepository(),
             whiteboardObjectSet: WhiteboardObjectSet())
         cancellables = []
     }
@@ -434,9 +435,39 @@ final class MockProfileRepository: ProfileRepositoryInterface {
 }
 
 final class MockWhiteObjectRepository: WhiteboardObjectRepositoryInterface {
-    var delegate: (any Domain.WhiteboardObjectRepositoryDelegate)?
+    var delegate: (any WhiteboardObjectRepositoryDelegate)?
 
-    func send(whiteboardObject: Domain.WhiteboardObject, isDeleted: Bool) async {
-        return
+    func send(
+        whiteboardObject: WhiteboardObject,
+        isDeleted: Bool,
+        to profile: Profile
+    ) async {}
+
+    func send(
+        whiteboardObjects: [WhiteboardObject],
+        isDeleted: Bool,
+        to profile: Profile
+    ) async {}
+
+    func send(whiteboardObject: WhiteboardObject, isDeleted: Bool) async {}
+}
+
+final class MockWhiteboardRepository: WhiteboardRepositoryInterface {
+    var delegate: (any WhiteboardRepositoryDelegate)?
+    var recentPeerPublisher: AnyPublisher<Domain.Profile, Never>
+    private var recentPeerSubject = PassthroughSubject<Domain.Profile, Never>()
+
+    init() {
+        recentPeerPublisher = recentPeerSubject.eraseToAnyPublisher()
     }
+
+    func startPublishing(myProfile: Profile) {}
+
+    func stopSearching() {}
+
+    func startSearching() {}
+
+    func disconnectWhiteboard() {}
+
+    func joinWhiteboard(whiteboard: Domain.Whiteboard, myProfile: Domain.Profile) throws {}
 }

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -117,7 +117,7 @@ extension NearbyNetworkService: NearbyNetworkInterface {
     }
 
     public func send(fileURL: URL, info: DataSource.DataInformationDTO) async {
-        let infoJsonData = try? JSONEncoder().encode(info)
+        let infoJsonData = try? encoder.encode(info)
 
         guard
             let infoJsonData,
@@ -145,14 +145,14 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         info: DataSource.DataInformationDTO,
         to connection: NetworkConnection
     ) async {
-        let infoJsonData = try? JSONEncoder().encode(info)
+        let infoJsonData = try? encoder.encode(info)
 
         guard
             let infoJsonData,
             let infoJsonString = String(data: infoJsonData, encoding: .utf8),
             let peer = session
                 .connectedPeers
-                .first(where: { $0.displayName == connection.id.uuidString})
+                .first(where: { $0.displayName == connection.id.uuidString })
         else { return }
 
         do {

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -141,6 +141,26 @@ extension NearbyNetworkService: NearbyNetworkInterface {
             }
         }
     }
+
+    public func send(
+        fileURL: URL,
+        info: DataSource.DataInformationDTO,
+        to connection: NetworkConnection
+    ) async {
+        let infoJsonData = try? JSONEncoder().encode(info)
+
+        guard
+            let infoJsonData,
+            let infoJsonString = String(data: infoJsonData, encoding: .utf8),
+            let peer = connectedPeers.first(where: {$0.value == connection})?.key
+        else { return }
+
+        do {
+            try await session.sendResource(at: fileURL, withName: infoJsonString, toPeer: peer)
+        } catch {
+            self.logger.log(level: .error, "\(peer)에게 file 데이터 전송 실패")
+        }
+    }
 }
 
 // MARK: - MCSessionDelegate

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -91,9 +91,7 @@ extension NearbyNetworkService: NearbyNetworkInterface {
             .first { $0.value.id == connection.id }?
             .key
         // TODO: Error 수정
-        guard let peerID else {
-            throw NSError()
-        }
+        guard let peerID else { throw NSError() }
 
         do {
             let encodedContext = try encoder.encode(context)
@@ -152,11 +150,14 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         guard
             let infoJsonData,
             let infoJsonString = String(data: infoJsonData, encoding: .utf8),
-            let peer = connectedPeers.first(where: {$0.value == connection})?.key
+            let peer = session
+                .connectedPeers
+                .first(where: { $0.displayName == connection.id.uuidString})
         else { return }
 
         do {
             try await session.sendResource(at: fileURL, withName: infoJsonString, toPeer: peer)
+            self.logger.log(level: .error, "\(peer)에게 file 데이터 전송 성공")
         } catch {
             self.logger.log(level: .error, "\(peer)에게 file 데이터 전송 실패")
         }

--- a/Persistence/Persistence/Souces/FilePersistence.swift
+++ b/Persistence/Persistence/Souces/FilePersistence.swift
@@ -20,10 +20,9 @@ public struct FilePersistence: FilePersistenceInterface {
 
     public func save(dataInfo: DataInformationDTO, data: Data?) -> URL? {
         guard let directoryURL = documentDirectoryURL?
-            .appendingPathComponent(
-                dataInfo
-                    .type
-                    .directoryName)
+            .appending(path: dataInfo
+                .type
+                .directoryName)
         else { return nil }
 
         createDirectory(at: directoryURL.path)
@@ -46,6 +45,23 @@ public struct FilePersistence: FilePersistenceInterface {
         return data
     }
 
+    public func fetchURL(dataInfo: DataInformationDTO) -> URL? {
+        guard let directoryURL = documentDirectoryURL?
+            .appendingPathComponent(
+                dataInfo
+                    .type
+                    .directoryName)
+        else { return nil }
+
+        let fileURL = directoryURL.appending(path: "\(dataInfo.id.uuidString)")
+
+        if fileManager.fileExists(atPath: fileURL.path()) {
+            return fileURL
+        } else {
+            return nil
+        }
+    }
+
     private func createDirectory(at path: String) {
         do {
             try fileManager.createDirectory(
@@ -62,7 +78,7 @@ public struct FilePersistence: FilePersistenceInterface {
         with data: Data?,
         fileName: String
     ) -> URL {
-        let fileURL = url.appendingPathComponent("\(fileName)")
+        let fileURL = url.appending(path: "\(fileName)")
 
         do {
             try data?.write(to: fileURL)

--- a/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
@@ -11,6 +11,7 @@ public protocol WhiteboardObjectViewFactoryable {
     var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate? { get set }
     var textViewDelegate: UITextViewDelegate? { get set }
     var gameObjectViewDelegate: GameObjectViewDelegate? { get set }
+    var photoObjectViewDelegate: PhotoObjectViewDelegate? { get set }
     func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView?
 }
 
@@ -18,6 +19,7 @@ public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
     public weak var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate?
     public weak var textViewDelegate: UITextViewDelegate?
     public weak var gameObjectViewDelegate: GameObjectViewDelegate?
+    public weak var photoObjectViewDelegate: PhotoObjectViewDelegate?
 
     public init() {}
 
@@ -30,7 +32,9 @@ public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
         case let drawingObject as DrawingObject:
             whiteboardObjectView = DrawingObjectView(drawingObject: drawingObject)
         case let photoObject as PhotoObject:
-            whiteboardObjectView = PhotoObjectView(photoObject: photoObject)
+            whiteboardObjectView = PhotoObjectView(
+                photoObject: photoObject,
+                photoObjectDelegate: photoObjectViewDelegate)
         case let gameObject as GameObject:
             whiteboardObjectView = GameObjectView(
                 gameObject: gameObject,

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/PhotoObjectView.swift
@@ -8,14 +8,20 @@
 import Domain
 import UIKit
 
-final class PhotoObjectView: WhiteboardObjectView {
-    let imageView = UIImageView()
+public protocol PhotoObjectViewDelegate: AnyObject {
+    func photoObjectViewWillConfigurePhoto(_ sender: PhotoObjectView)
+}
 
-    init(photoObject: PhotoObject) {
+public final class PhotoObjectView: WhiteboardObjectView {
+    let imageView = UIImageView()
+    weak var photoObjectDelegate: PhotoObjectViewDelegate?
+
+    init(photoObject: PhotoObject, photoObjectDelegate: PhotoObjectViewDelegate?) {
         super.init(whiteboardObject: photoObject)
+        self.photoObjectDelegate = photoObjectDelegate
+
         configureAttribute()
         configureLayout()
-        configureImage(with: photoObject.photoURL)
     }
 
     required init?(coder: NSCoder) {
@@ -24,6 +30,7 @@ final class PhotoObjectView: WhiteboardObjectView {
 
     private func configureAttribute() {
         imageView.contentMode = .scaleAspectFit
+        self.photoObjectDelegate?.photoObjectViewWillConfigurePhoto(self)
     }
 
     override func configureLayout() {
@@ -35,16 +42,10 @@ final class PhotoObjectView: WhiteboardObjectView {
 
     override func update(with object: WhiteboardObject) {
         super.update(with: object)
-        guard let photoObject = object as? PhotoObject else { return }
-        configureImage(with: photoObject.photoURL)
+        photoObjectDelegate?.photoObjectViewWillConfigurePhoto(self)
     }
 
-    private func configureImage(with imageURL: URL) {
-        guard
-            let imageData = try? Data(contentsOf: imageURL),
-            let image = UIImage(data: imageData)
-        else { return }
-
-        imageView.image = image
+    func configureImage(imageData: Data) {
+        imageView.image = UIImage(data: imageData)
     }
 }

--- a/Presentation/Presentation/Sources/Wordle/View/WordleView.swift
+++ b/Presentation/Presentation/Sources/Wordle/View/WordleView.swift
@@ -129,10 +129,10 @@ struct WordleView: View {
                                 viewModel.keyboard[row][col].alphabet == nil ? enterKeyboardWidth : keyboardWidth,
                             keyboardHeight: keyboardHeight) {
                                 viewModel.action(input: .typeKeyboard(keyboard: viewModel.keyboard[row][col]))
-                            }
-                            .disabled(
-                                viewModel.keyboard[row][col].keyboardState == .enter ?
-                                !viewModel.canSubmitWordle : viewModel.isGameOver)
+                        }
+                        .disabled(
+                            viewModel.keyboard[row][col].keyboardState == .enter ?
+                            !viewModel.canSubmitWordle : viewModel.isGameOver)
                     }
                 }
             }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
이제 존재하는 화이트보드에 입장하면 호스트가 새로 참여한 참여자에게 데이터들을 전송해줍니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 사진 오브젝트 전송 방식 수정
- 사진 오브젝트 뷰에서 사진을 표시하는 방법 수정

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
오브젝트를 전송하는 repository에는 세가지 종류의 퍼블릭 메서드가 있는데요,

1. 모든 사람들에게 오브젝트 전송
2. 특정 사람에게 오브젝트 전송
3. 특정 사람들에게 오브젝트 배열 전송

이중 3번 메서드는 repository구현체에서 2번 메서드를 호출함으로서 구현했습니다.
중복 코드를 줄이고자, 1, 2번 메서드는 private으로 선언된 send메서드를 호출합니다. 이 과정에서 아래와 같은 이유로 photo 오브젝트를 전송하는 부분이 계속 눈에 밟혀서 함께 수정했습니다. 

- photoObject에는 사진이 저장된 url이 프로퍼티로 존재함!! 하지만 기기마다 사진이 저장된 url이 다를 수 있어 사진 오브젝트만 전송했을 때 사진을 제대로 표시하지 못할 수 있음
- 실제 사진이 저장되는 경로는 photoObject의 ID만 알고 있다면 알 수 있음
- photoObjectView에서 사진데이터를 직접 꺼내와서 imageView를 설정함
