### PR TITLE
[Fix] 키보드 변경에 따른 UI 오류 수정

### DIFF
--- a/Presentation/Presentation/Sources/Chat/View/ChatViewController.swift
+++ b/Presentation/Presentation/Sources/Chat/View/ChatViewController.swift
@@ -82,12 +82,6 @@ public final class ChatViewController: UIViewController {
     }
 
     private func configureLayout() {
-        chatListView
-            .addToSuperview(view)
-            .horizontalEdges(equalTo: view, inset: horizontalMargin)
-            .top(equalTo: view.safeAreaLayoutGuide.topAnchor, inset: 0)
-//            .bottom(equalTo: chatTextFieldView.topAnchor, inset: ChatLayoutConstant.textFieldTopPadding)
-
         chatTextFieldView
             .addToSuperview(view)
             .height(equalTo: ChatLayoutConstant.textFieldHeight)
@@ -95,6 +89,9 @@ public final class ChatViewController: UIViewController {
             .bottom(equalTo: view.safeAreaLayoutGuide.bottomAnchor, inset: ChatLayoutConstant.textFieldBottomPadding)
 
         chatListView
+            .addToSuperview(view)
+            .horizontalEdges(equalTo: view, inset: horizontalMargin)
+            .top(equalTo: view.safeAreaLayoutGuide.topAnchor, inset: 0)
             .bottom(equalTo: chatTextFieldView.topAnchor, inset: ChatLayoutConstant.textFieldTopPadding)
     }
 


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
키보드의 유무에 따라 Layout을 변경 해주는 코드에서 키보드가 이모티콘 키보드로 변경시에도 키보드를 올렸다는 이벤트가 NotificationCenter에서 발생하는 것을 발견 해 고쳤습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
### 수정하기 전
![Simulator Screen Recording - iPhone 16 Pro - 2024-12-01 at 23 51 43](https://github.com/user-attachments/assets/c5186d42-0eff-41a0-91f2-f252474ec38d)

### 수정 후
![Simulator Screen Recording - iPhone 16 Pro - 2024-12-01 at 23 49 23](https://github.com/user-attachments/assets/ece4f93f-3a18-4e01-8d5d-7cf14de37fa0)

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
키보드에 따라 뷰 layout변경하는 부분을 수정했습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
채팅 뷰에 들어가서 채팅을 보낼 때 키보드를 변경 해보시면 됩니다.