### PR TITLE
[Fix] 프로필 텍스트필드 자음, 모음 분리 현상 개선 및 한글 글자 수 제한

### DIFF
--- a/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
+++ b/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
@@ -232,8 +232,8 @@ final class ProfileViewController: UIViewController {
         guard let currentText = textField.text else { return }
         var updatedText = currentText
 
-        if updatedText.count > 15 {
-            updatedText = String(updatedText.prefix(15))
+        if updatedText.count > nicknameMaxCount {
+            updatedText = String(updatedText.prefix(nicknameMaxCount))
             textField.text = updatedText
         }
         viewModel.action(input: .updateProfileNickname(nickname: updatedText))
@@ -260,7 +260,7 @@ extension ProfileViewController: UITextFieldDelegate {
         let koreanCharacterSet = CharacterSet(charactersIn: "가"..."힣")
         let containsKorean = updatedText.unicodeScalars.contains { koreanCharacterSet.contains($0) }
 
-        let maxLength = containsKorean ? 16 : 15
+        let maxLength = containsKorean ? nicknameMaxCount + 1 : nicknameMaxCount
         if updatedText.count > maxLength {
             return false
         }

--- a/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
+++ b/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
@@ -121,6 +121,12 @@ final class ProfileViewController: UIViewController {
                 self.showSelectProfileIconView()
             }, for: .touchUpInside)
 
+        nicknameTextField.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                self.textFieldDidChange(self.nicknameTextField)
+            }, for: .editingChanged)
+
         nicknameTextField.delegate = self
     }
 
@@ -221,26 +227,45 @@ final class ProfileViewController: UIViewController {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         view.endEditing(true)
     }
+
+    func textFieldDidChange(_ textField: UITextField) {
+        guard let currentText = textField.text else { return }
+        var updatedText = currentText
+
+        if updatedText.count > 15 {
+            updatedText = String(updatedText.prefix(15))
+            textField.text = updatedText
+        }
+        viewModel.action(input: .updateProfileNickname(nickname: updatedText))
+    }
 }
 
 // MARK: - UITextFieldDelegate
 extension ProfileViewController: UITextFieldDelegate {
-    public func textField(
+    func textField(
         _ textField: UITextField,
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String
     ) -> Bool {
-        if range.location == 0 && string == " " {
+        let currentText = textField.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let updatedText = currentText.replacingCharacters(in: stringRange, with: string)
+
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet.whitespaces)
+        let characterSet = CharacterSet(charactersIn: string)
+        if !allowedCharacters.isSuperset(of: characterSet) {
             return false
         }
-        let currentText = textField.text ?? ""
-        let updatedText = (currentText as NSString).replacingCharacters(in: range, with: string)
 
-        if updatedText.count <= nicknameMaxCount {
-            viewModel.action(input: .updateProfileNickname(nickname: updatedText))
-            return true
+        let koreanCharacterSet = CharacterSet(charactersIn: "가"..."힣")
+        let containsKorean = updatedText.unicodeScalars.contains { koreanCharacterSet.contains($0) }
+
+        let maxLength = containsKorean ? 16 : 15
+        if updatedText.count > maxLength {
+            return false
         }
-        return false
+
+        return true
     }
 
     public func textFieldShouldClear(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 프로필 설정 텍스트필드에 있던 자음, 모음 분리 버그 픽스
- 한글 글자 수 제한 로직 변경
- 특수 문자 입력 제한(공백은 허용)

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/5dd7518a-7010-49c9-a7b5-0e504ed63a8c

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 자음, 모음 분리 현상 개선
- 특수 문자 입력 제한
- 한글은 영어와 다르게 자음과 모음의 조합입니다. ex) 안, 맑 등등
    - 때문에 한글이 입력될 경우 16자 까지 허용한 뒤 15자리까지 잘라내는 식으로 로직을 짰습니다. 

## ✅ Testing
- 시뮬레이터에서 텍스트 입력 시 테스트 가능합니다. 
- 테스트 상황
    - 한글 입력 시 자음과 모음이 분리되지 않는지
    - 15번째 한글 입력 시 자음과 모음의 조합으로 입력되는지
    - 특수문자가 입력되지않는지(공백 제외)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 구글링을 하다가 자음, 모음의 조합이 가능한 모든 경우의 수에 대응하는 텍스트필드 델리게이트 메소드를 보았는데.. 나중에 이해하고 적용해보겠습니다. 
- 아마 그 방식을 쓰면 16자리 까지 받고 자르는 로직을 쓰지 않아도 될거같습니다. 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 
