### PR TITLE
[Fix] WhiteboardObjectUseCase 프로필 load 시점 변경

### DIFF
--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -19,7 +19,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
     private let removedWhiteboardSubject: PassthroughSubject<WhiteboardObject, Never>
     private let selectedObjectIDSubject: CurrentValueSubject<UUID?, Never>
     private let whiteboardRepository: WhiteboardRepositoryInterface
-    private let myProfile: Profile
+    private let profileRepository: ProfileRepositoryInterface
     private var whiteboardObjectRepository: WhiteboardObjectRepositoryInterface
     private var whiteboardObjectSet: WhiteboardObjectSetInterface
     private var cancellables: Set<AnyCancellable>
@@ -43,7 +43,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         self.whiteboardObjectSet = whiteboardObjectSet
         self.whiteboardObjectRepository = whiteboardObjectRepository
         self.whiteboardRepository = whiteboardRepository
-        myProfile = profileRepository.loadProfile()
+        self.profileRepository = profileRepository
         cancellables = []
         self.whiteboardObjectRepository.delegate = self
 
@@ -88,6 +88,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         removedWhiteboardSubject.send(object)
 
         if !isReceivedObject {
+            let myProfile = profileRepository.loadProfile()
             guard object.selectedBy == myProfile else { return false }
             await whiteboardObjectRepository.send(whiteboardObject: object, isDeleted: true)
         }
@@ -104,6 +105,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
             object.selectedBy == nil
         else { return false }
 
+        let myProfile = profileRepository.loadProfile()
         object.select(by: myProfile)
         await updateObject(whiteboardObject: object, isReceivedObject: false)
         selectedObjectIDSubject.send(whiteboardObjectID)
@@ -112,6 +114,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func deselect() async -> Bool {
+        let myProfile = profileRepository.loadProfile()
         guard let selectedObjectID = selectedObjectIDSubject.value else { return false }
 
         guard
@@ -130,6 +133,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
         scale: CGFloat,
         angle: CGFloat
     ) async -> Bool {
+        let myProfile = profileRepository.loadProfile()
         guard
             let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID),
             object.selectedBy == myProfile
@@ -143,6 +147,7 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
 
     @discardableResult
     public func changePosition(whiteboardObjectID: UUID, to position: CGPoint) async -> Bool {
+        let myProfile = profileRepository.loadProfile()
         guard
             let object = await whiteboardObjectSet.fetchObjectByID(id: whiteboardObjectID),
             object.selectedBy == myProfile


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

WhiteboardObjectUseCase init시 프로필을 가져오니까 프로필을 바꾼 후에도 이전 프로필을 가져오는 이슈가 있었습니다.     
init시에는 profileRepository만 받고 profile 사용 시에 load할 수 있도록 변경하였습니다.    

## 📱 Screenshot
로직 변경이라 한 기기 테스트 영상만 첨부하겠습니다.    
![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-12-02 at 17 49 42](https://github.com/user-attachments/assets/0e8b392f-8434-4b36-8929-defdcfc02674)

## 👩‍💻 Contents
myProfile이 필요한 함수마다 profileRepository에서 profile을 load해서 사용하도록 수정하였습니다.    


## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
화이트보드에서 오브젝트 선택 시 변경된 프로필 이모지로 잘 표시되는지 확인해보세요 ! 


## 📝 Review Note
프로필을 load하는 것이 반복된다고 생각이 드는데 ... 그렇다고 초기에 profile를 load 해놓을 순 없어 일단 이렇게 했습니다 .. .. .
더 나은 방법이 있다면 언제든 웰끔
