### PR TITLE
[Fix] 닉네임 설정 시 공백 제거 로직 추가 및 프로필 설정 화면 재 진입 시 설정된 프로필 로드

### DIFF
--- a/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
+++ b/Presentation/Presentation/Sources/Profile/View/ProfileViewController.swift
@@ -196,7 +196,11 @@ final class ProfileViewController: UIViewController {
     private func updateProfileState(nickname: String) {
         nicknameCountLabel.text = "\(nickname.count)/\(nicknameMaxCount)"
         nicknameTextField.text = nickname
-        if !nickname.isEmpty {
+        let trimmedNickname = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !nickname.isEmpty,
+           !trimmedNickname.isEmpty
+        {
             completeButton.isEnabled = true
             completeButton.tintColor = .airplainBlue
         } else {
@@ -216,10 +220,18 @@ final class ProfileViewController: UIViewController {
     }
 
     @objc private func dismissView() {
+        viewModel.action(input: .resetProfile)
         dismiss(animated: true)
     }
 
     @objc private func saveProfile() {
+        guard
+            let completedNickname = nicknameTextField
+                .text?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return }
+
+        viewModel.action(input: .updateProfileNickname(nickname: completedNickname))
         viewModel.action(input: .saveProfile)
         dismiss(animated: true)
     }

--- a/Presentation/Presentation/Sources/Profile/ViewModel/ProfileViewModel.swift
+++ b/Presentation/Presentation/Sources/Profile/ViewModel/ProfileViewModel.swift
@@ -14,6 +14,7 @@ public final class ProfileViewModel: ViewModel {
         case updateProfileNickname(nickname: String)
         case updateProfileIcon(profileIcon: ProfileIcon)
         case saveProfile
+        case resetProfile
     }
 
     struct Output {
@@ -33,9 +34,14 @@ public final class ProfileViewModel: ViewModel {
 
     func action(input: Input) {
         switch input {
-        case .updateProfileNickname(let nickname): updateProfileNickname(nickname: nickname)
-        case .updateProfileIcon(let profileIcon): updateProfileIcon(profileIcon: profileIcon)
-        case .saveProfile: saveProfile()
+        case .updateProfileNickname(let nickname):
+            updateProfileNickname(nickname: nickname)
+        case .updateProfileIcon(let profileIcon):
+            updateProfileIcon(profileIcon: profileIcon)
+        case .saveProfile:
+            saveProfile()
+        case .resetProfile:
+            resetProfile()
         }
     }
 
@@ -51,5 +57,9 @@ public final class ProfileViewModel: ViewModel {
 
     private func saveProfile() {
         profileUseCase.saveProfile(profile: profileSubject.value)
+    }
+
+    private func resetProfile() {
+        profileSubject.value = profileUseCase.loadProfile()
     }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 닉네임 설정 시 공백 처리
- 닉네임 설정 도중 화면 재 진입 시 원래 닉네임이 표시되지않는 버그 픽스

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
https://github.com/user-attachments/assets/8ed324c9-c8c9-4a7b-9438-85b44141eb3a

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 닉네임 설정 시 공백 처리
    - 입력 도중 공백을 처리하기에는 닉네임에 공백을 허용한 시점에서 조금 어렵다고 판단되어, 닉네임을 등록할 때 앞, 뒤의 공백을 모두 제거하는 방식으로 구현했습니다. 
    - 텍스트필드에 순수 공백만 존재한다면 완료 버튼을 비활성화 합니다. 
- 닉네임 설정 도중 방을 나간 뒤 돌아오면 편집중인 닉네임이 그대로 남아있는 버그를 수정했습니다. 

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
- 닉네임 맨 앞, 맨 뒤에 공백이 있는 상황
- 텍스트필드의 텍스트가 공백만으로 이루어진 상황
- 닉네임 편집 도중 "x" 버튼을 눌러 밖으로 나갔다가 재 진입하는 상황

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #3 
