### PR TITLE
[Fix] 오브젝트 수정 기능 QA 반영

### DIFF
--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -142,8 +142,7 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
         do {
             guard
                 isHost,
-                let context = context,
-                let prevInfo = self.participantsInfo["participants"]
+                let context = context
             else { return }
 
             let decodedContext = try JSONDecoder().decode(RequestedContext.self, from: context)

--- a/Domain/Domain/Sources/Interface/Repository/PhotoRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/PhotoRepositoryInterface.swift
@@ -13,6 +13,7 @@ public protocol PhotoRepositoryInterface {
     ///  id: 사진의 id
     ///  imageData: 사진 이미지 데이터
     /// - Returns: 저장한 위치 URL
+    @discardableResult
     func savePhoto(id: UUID, imageData: Data) -> URL?
 
     /// 저장된 사진을 가져옵니다

--- a/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/ManageWhiteboardObjectUseCaseInterface.swift
@@ -75,4 +75,7 @@ public protocol ManageWhiteboardObjectUseCaseInterface {
         whiteboardObjectID: UUID,
         scale: CGFloat,
         angle: CGFloat) async -> Bool
+
+    /// 화이트보드 오브젝트들을 모두 삭제합니다.
+    func removeAllWhiteboardObjects()
 }

--- a/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
+++ b/Domain/Domain/Sources/Interface/WhiteboardObjectSetInterface.swift
@@ -22,6 +22,9 @@ public protocol WhiteboardObjectSetInterface {
     /// - Parameter object: 삭제할 오브젝트
     func remove(object: WhiteboardObject) async
 
+    /// 모든 화이트보드 오브젝트들을 삭제합니다.
+    func removeAll() async
+
     /// 집합에 있는 오브젝트를 업데이트 합니다.
     /// - Parameter object: 업데이트할 오브젝트
     func update(object: WhiteboardObject) async

--- a/Domain/Domain/Sources/Model/WhiteboardObjectSet.swift
+++ b/Domain/Domain/Sources/Model/WhiteboardObjectSet.swift
@@ -26,6 +26,10 @@ public actor WhiteboardObjectSet: WhiteboardObjectSetInterface {
         whiteboardObjects.remove(object)
     }
 
+    public func removeAll() async {
+        whiteboardObjects.removeAll()
+    }
+
     public func update(object: WhiteboardObject) {
         remove(object: object)
         insert(object: object)

--- a/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/ManageWhiteboardObjectUseCase.swift
@@ -180,6 +180,12 @@ public final class ManageWhiteboardObjectUseCase: ManageWhiteboardObjectUseCaseI
             }
         }
     }
+
+    public func removeAllWhiteboardObjects() {
+        Task {
+            await whiteboardObjectSet.removeAll()
+        }
+    }
 }
 
 extension ManageWhiteboardObjectUseCase: WhiteboardObjectRepositoryDelegate {

--- a/Domain/Domain/Sources/UseCase/PhotoUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/PhotoUseCase.swift
@@ -21,6 +21,8 @@ public final class PhotoUseCase: PhotoUseCaseInterface {
     ) -> PhotoObject? {
         let id = UUID()
 
+        photoRepository.savePhoto(id: id, imageData: imageData)
+
         var size = size
         let scaleFactor = size.width >= size.height ? 200 / size.width : 200 / size.height
         size.width *= scaleFactor

--- a/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/TextObjectUseCase.swift
@@ -22,7 +22,7 @@ public final class TextObjectUseCase: TextObjectUseCaseInterface {
             id: UUID(),
             centerPosition: point,
             size: textFieldDefaultSize,
-            text: "Hello, AirplaIN!")
+            text: "")
     }
 
     public func editText(id: UUID, text: String) async {

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -211,7 +211,7 @@ extension NearbyNetworkService: MCSessionDelegate {
         didReceive data: Data,
         fromPeer peerID: MCPeerID
     ) {
-        guard let connection = connectedPeers[peerID] else {
+        guard connectedPeers[peerID] != nil else {
             logger.log(level: .error, "\(peerID.displayName)와 연결되어 있지 않음")
             return
         }

--- a/Presentation/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation/Presentation.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0080E8CA2CE2FF750095B958 /* WhiteboardObjectViewFactoryable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8C92CE2FF6E0095B958 /* WhiteboardObjectViewFactoryable.swift */; };
 		0080E8D12CE4A00F0095B958 /* WhiteboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */; };
 		0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8D22CE4A0820095B958 /* ViewModel.swift */; };
+		00C2950B2CFDF14700BD6768 /* AirplainTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C2950A2CFDF14700BD6768 /* AirplainTextField.swift */; };
 		00CCC2672CE60BCD005FA747 /* AirplainFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8525DC72CE201D50089DA5E /* AirplainFont.swift */; };
 		00D2DD982CE8CD300089F0BA /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D2DD972CE8CD300089F0BA /* DrawingView.swift */; };
 		00D2DD9A2CE8DCEA0089F0BA /* DrawingObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D2DD992CE8DCEA0089F0BA /* DrawingObjectView.swift */; };
@@ -25,6 +26,13 @@
 		6F199EF32CE3203A005DC40F /* WhiteboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F199EF22CE3203A005DC40F /* WhiteboardViewController.swift */; };
 		6F1EB9A72CF83538000EECB7 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1EB9A62CF83538000EECB7 /* HapticManager.swift */; };
 		6F21477D2CE4EFCF00B55E2C /* TextObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21477C2CE4EFCF00B55E2C /* TextObjectView.swift */; };
+		6F25BE442CF5BC44005BCAA2 /* PeerMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25BE432CF5BC44005BCAA2 /* PeerMessageCell.swift */; };
+		6F25BE472CF5BF79005BCAA2 /* ChatMessageCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25BE462CF5BF6F005BCAA2 /* ChatMessageCellModel.swift */; };
+		6FA7DBE92CF4B4E1007333C6 /* ChatTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBE82CF4B4E1007333C6 /* ChatTextFieldView.swift */; };
+		6FA7DBEC2CF56103007333C6 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBEB2CF56103007333C6 /* ChatViewModel.swift */; };
+		6FA7DBEE2CF56457007333C6 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBED2CF56457007333C6 /* MessageCell.swift */; };
+		6FA7DBF02CF5665B007333C6 /* MyMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBEF2CF5665B007333C6 /* MyMessageCell.swift */; };
+		6FA7DBF22CF56A3F007333C6 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBF12CF56A3F007333C6 /* ChatViewController.swift */; };
 		A81E7ABB2CF5C771007E8414 /* Wordle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7ABA2CF5C771007E8414 /* Wordle.swift */; };
 		A81E7ABD2CF5C7A7007E8414 /* WordleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7ABC2CF5C7A7007E8414 /* WordleState.swift */; };
 		A81E7ABF2CF5C7FE007E8414 /* KeyboardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7ABE2CF5C7FE007E8414 /* KeyboardState.swift */; };
@@ -35,13 +43,6 @@
 		A81E7BD62CF6E797007E8414 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A81E7BD52CF6E797007E8414 /* Images.xcassets */; };
 		A81E7BD82CF6E94F007E8414 /* WordleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BD72CF6E94F007E8414 /* WordleView.swift */; };
 		A81E7BDB2CF6E973007E8414 /* WordleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BDA2CF6E973007E8414 /* WordleViewModel.swift */; };
-		6F25BE442CF5BC44005BCAA2 /* PeerMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25BE432CF5BC44005BCAA2 /* PeerMessageCell.swift */; };
-		6F25BE472CF5BF79005BCAA2 /* ChatMessageCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25BE462CF5BF6F005BCAA2 /* ChatMessageCellModel.swift */; };
-		6FA7DBE92CF4B4E1007333C6 /* ChatTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBE82CF4B4E1007333C6 /* ChatTextFieldView.swift */; };
-		6FA7DBEC2CF56103007333C6 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBEB2CF56103007333C6 /* ChatViewModel.swift */; };
-		6FA7DBEE2CF56457007333C6 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBED2CF56457007333C6 /* MessageCell.swift */; };
-		6FA7DBF02CF5665B007333C6 /* MyMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBEF2CF5665B007333C6 /* MyMessageCell.swift */; };
-		6FA7DBF22CF56A3F007333C6 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7DBF12CF56A3F007333C6 /* ChatViewController.swift */; };
 		A81E7BF52CF710EC007E8414 /* GameObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BF42CF710EC007E8414 /* GameObjectView.swift */; };
 		A8525DC32CE200230089DA5E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A8525DC22CE200230089DA5E /* Colors.xcassets */; };
 		A8525DCB2CE203D50089DA5E /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8525DCA2CE203D50089DA5E /* UIView+.swift */; };
@@ -78,6 +79,7 @@
 		0080E8C92CE2FF6E0095B958 /* WhiteboardObjectViewFactoryable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectViewFactoryable.swift; sourceTree = "<group>"; };
 		0080E8D02CE4A0060095B958 /* WhiteboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardViewModel.swift; sourceTree = "<group>"; };
 		0080E8D22CE4A0820095B958 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		00C2950A2CFDF14700BD6768 /* AirplainTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirplainTextField.swift; sourceTree = "<group>"; };
 		00D2DD972CE8CD300089F0BA /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
 		00D2DD992CE8DCEA0089F0BA /* DrawingObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingObjectView.swift; sourceTree = "<group>"; };
 		5B2BC78A2CE4F66F00893B9E /* WhiteboardListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardListViewController.swift; sourceTree = "<group>"; };
@@ -89,6 +91,13 @@
 		6F199EF22CE3203A005DC40F /* WhiteboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardViewController.swift; sourceTree = "<group>"; };
 		6F1EB9A62CF83538000EECB7 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		6F21477C2CE4EFCF00B55E2C /* TextObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectView.swift; sourceTree = "<group>"; };
+		6F25BE432CF5BC44005BCAA2 /* PeerMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerMessageCell.swift; sourceTree = "<group>"; };
+		6F25BE462CF5BF6F005BCAA2 /* ChatMessageCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCellModel.swift; sourceTree = "<group>"; };
+		6FA7DBE82CF4B4E1007333C6 /* ChatTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextFieldView.swift; sourceTree = "<group>"; };
+		6FA7DBEB2CF56103007333C6 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		6FA7DBED2CF56457007333C6 /* MessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
+		6FA7DBEF2CF5665B007333C6 /* MyMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMessageCell.swift; sourceTree = "<group>"; };
+		6FA7DBF12CF56A3F007333C6 /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		A81E7ABA2CF5C771007E8414 /* Wordle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wordle.swift; sourceTree = "<group>"; };
 		A81E7ABC2CF5C7A7007E8414 /* WordleState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordleState.swift; sourceTree = "<group>"; };
 		A81E7ABE2CF5C7FE007E8414 /* KeyboardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardState.swift; sourceTree = "<group>"; };
@@ -99,13 +108,6 @@
 		A81E7BD52CF6E797007E8414 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		A81E7BD72CF6E94F007E8414 /* WordleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordleView.swift; sourceTree = "<group>"; };
 		A81E7BDA2CF6E973007E8414 /* WordleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordleViewModel.swift; sourceTree = "<group>"; };
-		6F25BE432CF5BC44005BCAA2 /* PeerMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerMessageCell.swift; sourceTree = "<group>"; };
-		6F25BE462CF5BF6F005BCAA2 /* ChatMessageCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCellModel.swift; sourceTree = "<group>"; };
-		6FA7DBE82CF4B4E1007333C6 /* ChatTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTextFieldView.swift; sourceTree = "<group>"; };
-		6FA7DBEB2CF56103007333C6 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
-		6FA7DBED2CF56457007333C6 /* MessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
-		6FA7DBEF2CF5665B007333C6 /* MyMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyMessageCell.swift; sourceTree = "<group>"; };
-		6FA7DBF12CF56A3F007333C6 /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		A81E7BF42CF710EC007E8414 /* GameObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameObjectView.swift; sourceTree = "<group>"; };
 		A8525DC22CE200230089DA5E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		A8525DC72CE201D50089DA5E /* AirplainFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirplainFont.swift; sourceTree = "<group>"; };
@@ -213,6 +215,14 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		00C295092CFDF13700BD6768 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				00C2950A2CFDF14700BD6768 /* AirplainTextField.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		5B2BC78B2CE4F66F00893B9E /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -273,6 +283,52 @@
 			path = Manager;
 			sourceTree = "<group>";
 		};
+		6F25BE452CF5BF63005BCAA2 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				6F25BE462CF5BF6F005BCAA2 /* ChatMessageCellModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		6FA7DBE52CF4682F007333C6 /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				6F25BE452CF5BF63005BCAA2 /* Model */,
+				6FA7DBE72CF4B4DA007333C6 /* View */,
+				6FA7DBE62CF4685A007333C6 /* ViewModel */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
+		6FA7DBE62CF4685A007333C6 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				6FA7DBEB2CF56103007333C6 /* ChatViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		6FA7DBE72CF4B4DA007333C6 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				6FA7DBF12CF56A3F007333C6 /* ChatViewController.swift */,
+				6FA7DBE82CF4B4E1007333C6 /* ChatTextFieldView.swift */,
+				6FA7DBEA2CF560D5007333C6 /* Cell */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		6FA7DBEA2CF560D5007333C6 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				6FA7DBED2CF56457007333C6 /* MessageCell.swift */,
+				6FA7DBEF2CF5665B007333C6 /* MyMessageCell.swift */,
+				6F25BE432CF5BC44005BCAA2 /* PeerMessageCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		A81E7AB42CF5C6D4007E8414 /* Wordle */ = {
 			isa = PBXGroup;
 			children = (
@@ -313,52 +369,6 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
-    6FA7DBE52CF4682F007333C6 /* Chat */ = {
-        isa = PBXGroup;
-        children = (
-            6F25BE452CF5BF63005BCAA2 /* Model */,
-            6FA7DBE72CF4B4DA007333C6 /* View */,
-            6FA7DBE62CF4685A007333C6 /* ViewModel */,
-        );
-        path = Chat;
-        sourceTree = "<group>";
-    };
-    6FA7DBE62CF4685A007333C6 /* ViewModel */ = {
-        isa = PBXGroup;
-        children = (
-            6FA7DBEB2CF56103007333C6 /* ChatViewModel.swift */,
-        );
-        path = ViewModel;
-        sourceTree = "<group>";
-    };
-		6FA7DBE72CF4B4DA007333C6 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				6FA7DBF12CF56A3F007333C6 /* ChatViewController.swift */,
-				6FA7DBE82CF4B4E1007333C6 /* ChatTextFieldView.swift */,
-				6FA7DBEA2CF560D5007333C6 /* Cell */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		6FA7DBEA2CF560D5007333C6 /* Cell */ = {
-			isa = PBXGroup;
-			children = (
-				6FA7DBED2CF56457007333C6 /* MessageCell.swift */,
-				6FA7DBEF2CF5665B007333C6 /* MyMessageCell.swift */,
-				6F25BE432CF5BC44005BCAA2 /* PeerMessageCell.swift */,
-			);
-			path = Cell;
-			sourceTree = "<group>";
-		};
-    6F25BE452CF5BF63005BCAA2 /* Model */ = {
-        isa = PBXGroup;
-        children = (
-            6F25BE462CF5BF6F005BCAA2 /* ChatMessageCellModel.swift */,
-        );
-        path = Model;
-        sourceTree = "<group>";
-    };
 		A8525DC12CE200110089DA5E /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -371,6 +381,7 @@
 		A8525DC52CE201C00089DA5E /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				00C295092CFDF13700BD6768 /* View */,
 				6F1EB9A52CF8352F000EECB7 /* Manager */,
 				A8525DC92CE202D30089DA5E /* Extension */,
 				A8525DC62CE201CB0089DA5E /* DesignSystem */,
@@ -568,6 +579,7 @@
 				0080E8D32CE4A0840095B958 /* ViewModel.swift in Sources */,
 				5B2BC78E2CE4F66F00893B9E /* WhiteboardListViewController.swift in Sources */,
 				5B2BC78F2CE4F66F00893B9E /* WhiteboardListViewModel.swift in Sources */,
+				00C2950B2CFDF14700BD6768 /* AirplainTextField.swift in Sources */,
 				0080E8CA2CE2FF750095B958 /* WhiteboardObjectViewFactoryable.swift in Sources */,
 				A81E7BD42CF6E76D007E8414 /* WordleGuideView.swift in Sources */,
 				00683D762CE4B828000D28E4 /* DrawingRenderer.swift in Sources */,

--- a/Presentation/Presentation/Sources/Common/View/AirplainTextField.swift
+++ b/Presentation/Presentation/Sources/Common/View/AirplainTextField.swift
@@ -1,0 +1,59 @@
+//
+//  AirplainTextField.swift
+//  Presentation
+//
+//  Created by 이동현 on 12/2/24.
+//
+
+import UIKit
+
+public protocol AirplaINTextFieldDelegate: AnyObject, UITextFieldDelegate {
+    func airplainTextFieldDidChange(_ textField: AirplainTextField)
+}
+
+public final class AirplainTextField: UITextField {
+    weak var airplainTextFieldDelegate: AirplaINTextFieldDelegate? {
+        didSet {
+            delegate = airplainTextFieldDelegate
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureAttribute()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureAttribute()
+    }
+
+    private func configureAttribute() {
+        configurePlaceHolder()
+
+        self.addAction(
+            UIAction { [weak self] _ in
+                guard let self else { return }
+                self.airplainTextFieldDelegate?.airplainTextFieldDidChange(self)
+            },
+            for: .editingChanged)
+
+        self.addAction(
+            UIAction { [weak self] _ in
+                self?.attributedPlaceholder = nil
+            },
+            for: .editingDidBegin)
+
+        self.addAction(
+            UIAction { [weak self] _ in
+                self?.configurePlaceHolder()
+            },
+            for: .editingDidEnd)
+    }
+
+    private func configurePlaceHolder() {
+        let placeholderText = "Hello, AirplaIN"
+        let placeholderAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.airplainBlack]
+        self.attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: placeholderAttributes)
+    }
+}

--- a/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/Factory/WhiteboardObjectViewFactoryable.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public protocol WhiteboardObjectViewFactoryable {
     var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate? { get set }
-    var textViewDelegate: UITextViewDelegate? { get set }
+    var textFieldDelegate: AirplaINTextFieldDelegate? { get set }
     var gameObjectViewDelegate: GameObjectViewDelegate? { get set }
     var photoObjectViewDelegate: PhotoObjectViewDelegate? { get set }
     func create(with whiteboardObject: WhiteboardObject) -> WhiteboardObjectView?
@@ -17,7 +17,7 @@ public protocol WhiteboardObjectViewFactoryable {
 
 public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
     public weak var whiteboardObjectViewDelegate: WhiteboardObjectViewDelegate?
-    public weak var textViewDelegate: UITextViewDelegate?
+    public weak var textFieldDelegate: AirplaINTextFieldDelegate?
     public weak var gameObjectViewDelegate: GameObjectViewDelegate?
     public weak var photoObjectViewDelegate: PhotoObjectViewDelegate?
 
@@ -28,7 +28,7 @@ public struct WhiteboardObjectViewFactory: WhiteboardObjectViewFactoryable {
 
         switch whiteboardObject {
         case let textObject as TextObject:
-            whiteboardObjectView = TextObjectView(textObject: textObject, textViewDelegate: textViewDelegate)
+            whiteboardObjectView = TextObjectView(textObject: textObject, textFieldDelegate: textFieldDelegate)
         case let drawingObject as DrawingObject:
             whiteboardObjectView = DrawingObjectView(drawingObject: drawingObject)
         case let photoObject as PhotoObject:

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -9,23 +9,23 @@ import Domain
 import UIKit
 
 final class TextObjectView: WhiteboardObjectView {
-    private let textView: UITextView = {
-        let textView = UITextView()
-        textView.textAlignment = .center
-        textView.textColor = .airplainBlack
-        textView.isScrollEnabled = false
-        textView.backgroundColor = .clear
-        textView.isUserInteractionEnabled = false
-        return textView
+    private let textField: AirplainTextField = {
+        let textField = AirplainTextField()
+        textField.textAlignment = .center
+        textField.textColor = .airplainBlack
+        textField.backgroundColor = .clear
+        textField.isUserInteractionEnabled = false
+
+        return textField
     }()
 
     init(
         textObject: TextObject,
-        textViewDelegate: UITextViewDelegate?
+        textFieldDelegate: AirplaINTextFieldDelegate?
     ) {
         super.init(whiteboardObject: textObject)
         configureLayout()
-        textView.delegate = textViewDelegate
+        textField.airplainTextFieldDelegate = textFieldDelegate
     }
 
     required init?(coder: NSCoder) {
@@ -34,7 +34,7 @@ final class TextObjectView: WhiteboardObjectView {
     }
 
     override func configureLayout() {
-        textView
+        textField
             .addToSuperview(self)
             .edges(equalTo: self)
         super.configureLayout()
@@ -44,12 +44,12 @@ final class TextObjectView: WhiteboardObjectView {
         super.update(with: object)
         guard let textObject = object as? TextObject else { return }
 
-        textView.text = textObject.text
+        textField.text = textObject.text
     }
 
     override func configureEditable(isEditable: Bool) {
         super.configureEditable(isEditable: isEditable)
-        textView.isUserInteractionEnabled = isEditable
-        textView.resignFirstResponder()
+        textField.isUserInteractionEnabled = isEditable
+        textField.resignFirstResponder()
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/TextObjectView.swift
@@ -30,6 +30,7 @@ final class TextObjectView: WhiteboardObjectView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        configureLayout()
     }
 
     override func configureLayout() {
@@ -49,5 +50,6 @@ final class TextObjectView: WhiteboardObjectView {
     override func configureEditable(isEditable: Bool) {
         super.configureEditable(isEditable: isEditable)
         textView.isUserInteractionEnabled = isEditable
+        textView.resignFirstResponder()
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardObjectView.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/ObjectView/WhiteboardObjectView.swift
@@ -12,7 +12,6 @@ public protocol WhiteboardObjectViewDelegate: AnyObject {
         _ sender: WhiteboardObjectView,
         scale: CGFloat,
         angle: CGFloat)
-    func whiteboardObjectViewDidEndMoving(_ sender: WhiteboardObjectView, newCenter: CGPoint)
 }
 
 public class WhiteboardObjectView: UIView {
@@ -89,9 +88,6 @@ public class WhiteboardObjectView: UIView {
     private func configureAttribute() {
         let controlPanGesture = UIPanGestureRecognizer(target: self, action: #selector(handleControlPanning))
         controlView.addGestureRecognizer(controlPanGesture)
-
-        let moveGesture = UIPanGestureRecognizer(target: self, action: #selector(handleMoveObjectView))
-        addGestureRecognizer(moveGesture)
     }
 
     func configureLayout() {
@@ -253,26 +249,6 @@ public class WhiteboardObjectView: UIView {
             .identity
             .scaledBy(x: scale, y: scale)
             .rotated(by: angle)
-    }
-
-    @objc private func handleMoveObjectView(gesture: UIPanGestureRecognizer) {
-
-        let translation = gesture.translation(in: superview)
-        let newCenter = CGPoint(
-            x: center.x + translation.x,
-            y: center.y + translation.y
-        )
-
-        switch gesture.state {
-        case .possible, .began:
-            break
-        case .changed:
-            center = newCenter
-        default:
-            delegate?.whiteboardObjectViewDidEndMoving(self, newCenter: newCenter)
-        }
-
-        gesture.setTranslation(.zero, in: superview)
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardToolBar.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardToolBar.swift
@@ -81,11 +81,11 @@ final class WhiteboardToolBar: UIView {
     }
 
     func configureDeleteImage(isDeleteZoneEnable: Bool) {
-        let deleteImage = isDeleteZoneEnable ?
-        UIImage(systemName: WhiteboardToolBarLayoutConstant.deletionEnabledImage) :
-        UIImage(systemName: WhiteboardToolBarLayoutConstant.deletionDisabledImage)
+        let imageName = isDeleteZoneEnable
+        ? WhiteboardToolBarLayoutConstant.deletionEnabledImage
+        : WhiteboardToolBarLayoutConstant.deletionDisabledImage
 
-        deletionImage.image = deleteImage
+        deletionImage.image = UIImage(systemName: imageName)
     }
 
     private func configureAttribute() {

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardToolBar.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardToolBar.swift
@@ -21,7 +21,7 @@ final class WhiteboardToolBar: UIView {
 
     private enum WhiteboardToolBarLayoutConstant {
         static let toolbarSpacing: CGFloat = 30
-        static let deleteButtonWidth: CGFloat = 50
+        static let deleteButtonSize: CGFloat = 40
     }
 
     private let toolStackView = UIStackView()
@@ -30,15 +30,22 @@ final class WhiteboardToolBar: UIView {
     private let photo = UIButton()
     private let game = UIButton()
     private let chat = UIButton()
+
+    private let deleteButtonImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "trash.circle")
+        imageView.tintColor = .wordleRed
+        imageView.isHidden = true
+        return imageView
+    }()
+
     private let deleteButton: UIButton = {
         let button = UIButton()
-        button.setImage(
-            UIImage(systemName: "trash.circle"),
-            for: .normal)
-        button.tintColor = .wordleRed
+        button.backgroundColor = .clear
         button.isHidden = true
         return button
     }()
+
     private var tools: [WhiteboardTool: UIButton] = [:]
     weak var delegate: WhiteboardToolBarDelegate?
 
@@ -70,9 +77,11 @@ final class WhiteboardToolBar: UIView {
         case .normal:
             toolStackView.isHidden = false
             deleteButton.isHidden = true
+            deleteButtonImage.isHidden = true
         case .delete:
             toolStackView.isHidden = true
             deleteButton.isHidden = false
+            deleteButtonImage.isHidden = false
         }
     }
 
@@ -86,14 +95,18 @@ final class WhiteboardToolBar: UIView {
             .addToSuperview(self)
             .edges(equalTo: self)
 
+        deleteButtonImage
+            .addToSuperview(self)
+            .center(in: self)
+            .size(
+                width: WhiteboardToolBarLayoutConstant.deleteButtonSize,
+                height: WhiteboardToolBarLayoutConstant.deleteButtonSize)
         deleteButton
             .addToSuperview(self)
+            .center(in: self)
             .size(
-                width: WhiteboardToolBarLayoutConstant.deleteButtonWidth,
-                height: 40,
-                priority: .defaultLow)
-            .verticalEdges(equalTo: self)
-            .centerX(equalTo: self.centerXAnchor)
+                width: WhiteboardToolBarLayoutConstant.deleteButtonSize,
+                height: WhiteboardToolBarLayoutConstant.deleteButtonSize)
     }
 
     private func configureButtons() {

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardToolBar.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardToolBar.swift
@@ -10,7 +10,6 @@ import UIKit
 
 protocol WhiteboardToolBarDelegate: AnyObject {
     func whiteboardToolBar(_ sender: WhiteboardToolBar, selectedTool: WhiteboardTool)
-    func whiteboardToolBarDidTapDeleteButton(_ sender: WhiteboardToolBar)
 }
 
 final class WhiteboardToolBar: UIView {
@@ -21,7 +20,9 @@ final class WhiteboardToolBar: UIView {
 
     private enum WhiteboardToolBarLayoutConstant {
         static let toolbarSpacing: CGFloat = 30
-        static let deleteButtonSize: CGFloat = 40
+        static let deletionImageSize: CGFloat = 40
+        static let deletionDisabledImage = "trash.circle"
+        static let deletionEnabledImage = "trash.circle.fill"
     }
 
     private let toolStackView = UIStackView()
@@ -31,22 +32,18 @@ final class WhiteboardToolBar: UIView {
     private let game = UIButton()
     private let chat = UIButton()
 
-    private let deleteButtonImage: UIImageView = {
+    private let deletionImage: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "trash.circle")
+        imageView.image = UIImage(systemName: WhiteboardToolBarLayoutConstant.deletionDisabledImage)
         imageView.tintColor = .wordleRed
         imageView.isHidden = true
         return imageView
     }()
 
-    private let deleteButton: UIButton = {
-        let button = UIButton()
-        button.backgroundColor = .clear
-        button.isHidden = true
-        return button
-    }()
-
     private var tools: [WhiteboardTool: UIButton] = [:]
+    var deleteZone: CGRect {
+        return convert(deletionImage.frame, to: superview)
+    }
     weak var delegate: WhiteboardToolBarDelegate?
 
     override init(frame: CGRect) {
@@ -76,13 +73,19 @@ final class WhiteboardToolBar: UIView {
         switch mode {
         case .normal:
             toolStackView.isHidden = false
-            deleteButton.isHidden = true
-            deleteButtonImage.isHidden = true
+            deletionImage.isHidden = true
         case .delete:
             toolStackView.isHidden = true
-            deleteButton.isHidden = false
-            deleteButtonImage.isHidden = false
+            deletionImage.isHidden = false
         }
+    }
+
+    func configureDeleteImage(isDeleteZoneEnable: Bool) {
+        let deleteImage = isDeleteZoneEnable ?
+        UIImage(systemName: WhiteboardToolBarLayoutConstant.deletionEnabledImage) :
+        UIImage(systemName: WhiteboardToolBarLayoutConstant.deletionDisabledImage)
+
+        deletionImage.image = deleteImage
     }
 
     private func configureAttribute() {
@@ -95,18 +98,12 @@ final class WhiteboardToolBar: UIView {
             .addToSuperview(self)
             .edges(equalTo: self)
 
-        deleteButtonImage
+        deletionImage
             .addToSuperview(self)
             .center(in: self)
             .size(
-                width: WhiteboardToolBarLayoutConstant.deleteButtonSize,
-                height: WhiteboardToolBarLayoutConstant.deleteButtonSize)
-        deleteButton
-            .addToSuperview(self)
-            .center(in: self)
-            .size(
-                width: WhiteboardToolBarLayoutConstant.deleteButtonSize,
-                height: WhiteboardToolBarLayoutConstant.deleteButtonSize)
+                width: WhiteboardToolBarLayoutConstant.deletionImageSize,
+                height: WhiteboardToolBarLayoutConstant.deletionImageSize)
     }
 
     private func configureButtons() {
@@ -123,13 +120,6 @@ final class WhiteboardToolBar: UIView {
                 },
                 for: .touchUpInside )
         }
-
-        deleteButton.addAction(
-            UIAction { [weak self] _ in
-                guard let self else { return }
-                self.delegate?.whiteboardToolBarDidTapDeleteButton(self)
-            },
-            for: .touchUpInside)
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -54,7 +54,7 @@ public final class WhiteboardViewController: UIViewController {
         whiteboardObjectViews = [:]
         super.init(nibName: nil, bundle: nil)
         self.objectViewFactory.whiteboardObjectViewDelegate = self
-        self.objectViewFactory.textViewDelegate = self
+        self.objectViewFactory.textFieldDelegate = self
         self.objectViewFactory.gameObjectViewDelegate = self
         self.objectViewFactory.photoObjectViewDelegate = self
     }
@@ -425,27 +425,27 @@ extension WhiteboardViewController: WhiteboardObjectViewDelegate {
     }
 }
 
-extension WhiteboardViewController: UITextViewDelegate {
-    public func textView(
-        _ textView: UITextView,
-        shouldChangeTextIn range: NSRange,
-        replacementText text: String
+extension WhiteboardViewController: AirplaINTextFieldDelegate {
+    public func airplainTextFieldDidChange(_ textField: AirplainTextField) {
+        viewModel.action(input: .editTextObject(text: textField.text ?? ""))
+    }
+
+    public func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
     ) -> Bool {
-        guard text != "\n" else {
-            textView.resignFirstResponder()
+        guard string != "\n" else {
+            textField.resignFirstResponder()
             viewModel.action(input: .finishEditingTextObject)
             return false
         }
 
         let maxLength = 20
-        guard let originText = textView.text else { return true }
-        let newlength = originText.count + text.count - range.length
+        guard let originText = textField.text else { return true }
+        let newlength = originText.count + string.count - range.length
 
         return newlength < maxLength
-    }
-
-    public func textViewDidChange(_ textView: UITextView) {
-        viewModel.action(input: .editTextObject(text: textView.text ?? ""))
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -63,11 +63,16 @@ public final class WhiteboardViewController: UIViewController {
         fatalError("WhiteboardViewController 초기화 오류")
     }
 
+    deinit {
+        configureTearDownObserver()
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         configureLayout()
         configureAttribute()
         configureScrollView()
+        configureSetUpObserver()
         bind()
     }
 
@@ -221,6 +226,30 @@ public final class WhiteboardViewController: UIViewController {
         scrollView.addGestureRecognizer(scrollViewTapGestureRecognizer)
     }
 
+    private func configureSetUpObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyBoardWillAppear),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyBoardWillDisappear),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+    }
+
+    private func configureTearDownObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil)
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
+    }
+
     private func addObjectView(objectView: WhiteboardObjectView) {
         canvasView.addSubview(objectView)
     }
@@ -260,6 +289,20 @@ public final class WhiteboardViewController: UIViewController {
             chatMessages: viewModel.output.chatMessages)
         let chatViewController = ChatViewController(viewModel: chatViewModel)
         self.present(chatViewController, animated: true)
+    }
+
+    @objc private func keyBoardWillAppear(_ sender: Notification) {
+        guard
+            let keyBoardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+        else { return }
+
+        let keyboardHeight = keyBoardFrame.cgRectValue.height
+
+        canvasView.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+    }
+
+    @objc private func keyBoardWillDisappear(_ sender: Notification) {
+        canvasView.transform = .identity
     }
 }
 

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -63,11 +63,6 @@ public final class WhiteboardViewController: UIViewController {
         fatalError("WhiteboardViewController 초기화 오류")
     }
 
-    deinit {
-        viewModel.action(input: .removeAll)
-        configureTearDownObserver()
-    }
-
     public override func viewDidLoad() {
         super.viewDidLoad()
         configureLayout()
@@ -85,6 +80,8 @@ public final class WhiteboardViewController: UIViewController {
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.isNavigationBarHidden = true
+        viewModel.action(input: .removeAll)
+        configureTearDownObserver()
     }
 
     private func configureAttribute() {

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -64,6 +64,7 @@ public final class WhiteboardViewController: UIViewController {
     }
 
     deinit {
+        viewModel.action(input: .removeAll)
         configureTearDownObserver()
     }
 
@@ -274,6 +275,7 @@ public final class WhiteboardViewController: UIViewController {
         let objectViewPanGeture: UIPanGestureRecognizer
         objectViewPanGeture = UIPanGestureRecognizer(target: self, action: #selector(handleMoveObjectView))
         objectView.addGestureRecognizer(objectViewPanGeture)
+        objectViewPanGeture.isEnabled = false
 
         canvasView.addSubview(objectView)
     }

--- a/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/View/WhiteboardViewController.swift
@@ -342,12 +342,16 @@ public final class WhiteboardViewController: UIViewController {
 
     @objc private func keyBoardWillAppear(_ sender: Notification) {
         guard
-            let keyBoardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+            let keyBoardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
+            let selectedObjectView
         else { return }
 
         let keyboardHeight = keyBoardFrame.cgRectValue.height
+        let selectedObjectViewFrame = selectedObjectView.convert(selectedObjectView.bounds, to: view)
 
-        canvasView.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+        if selectedObjectViewFrame.midY > view.bounds.midY {
+            canvasView.transform = CGAffineTransform(translationX: 0, y: -keyboardHeight)
+        }
     }
 
     @objc private func keyBoardWillDisappear(_ sender: Notification) {

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -30,6 +30,7 @@ public final class WhiteboardViewModel: ViewModel {
         case checkIsDeletion(point: CGPoint, deletionZone: CGRect)
         case dragObject(point: CGPoint)
         case changeObjectPosition(point: CGPoint)
+        case removeAll
     }
 
     struct Output {
@@ -146,6 +147,8 @@ public final class WhiteboardViewModel: ViewModel {
             checkIsDeletionZoneEnable(with: point, deletionZone: deletionZone)
         case .dragObject(let point):
             dragObject(to: point)
+        case .removeAll:
+            removeAllWhiteboardObjects()
         }
     }
 
@@ -301,5 +304,9 @@ public final class WhiteboardViewModel: ViewModel {
                 self?.output.chatMessages.append(chatMessage)
             }
             .store(in: &cancellables)
+    }
+
+    private func removeAllWhiteboardObjects() {
+        manageWhiteboardObjectUseCase.removeAllWhiteboardObjects()
     }
 }

--- a/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
+++ b/Presentation/Presentation/Sources/Whiteboard/ViewModel/WhiteboardViewModel.swift
@@ -158,8 +158,7 @@ public final class WhiteboardViewModel: ViewModel {
     }
 
     private func finishUsingTool() {
-        let currentTool = manageWhiteboardToolUseCase.currentTool()
-        guard let currentTool else { return }
+        guard manageWhiteboardToolUseCase.currentTool() != nil else { return }
 
         manageWhiteboardToolUseCase.finishUsingTool()
     }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
금일 마스터 클래스에서 진행한 버그 트리아즈에서 오브젝트 수정 관련해서 들어온 QA들을 반영했습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->
- iPhone SE3  

https://github.com/user-attachments/assets/6ebbebae-eb44-4fc5-96aa-46bc8d9b6edb


- iPhone 13 mini

https://github.com/user-attachments/assets/3ebe89b8-2b0c-4373-a3c9-1ff418743ed9


- iPhone 16 Pro

https://github.com/user-attachments/assets/7d7ced4e-60ab-483d-b248-70e3ee35fbf4


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 사진이 추가되지 않던 문제 수정
- 오브젝트 삭제 버튼 크기 확대
- 오브젝트를 삭제 버튼을 탭해서 삭제 -> 삭제 영역으로 드래그하여 삭제로 변경
- 텍스트 오브젝트 뷰를 선택하면 바로 텍스트 수정을 위해 키보드가 올라오던 현상 수정
- 텍스트 편집 시 키보드가 삭제 버튼과 다른 오브젝트들을 가리던 문제 수정
- 텍스트 편집 시 return 키를 누르지 않아도 텍스트가 편집되도록 수정
- TextViewObject에 placeholder 제공
- UX를 위한 햅틱 반응 추가 


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 사진이 추가되지 않던 문제 수정
    - 멍청하게도.. 아침에 수정할 떄 사진 오브젝트 생성 시 사진을 파일 시스템에 저장하는 코드를 삭제했었습니다.
- 오브젝트 삭제 버튼 크기 확대
    - 이미지 크기를 40*40로 수정했습니다.
- 오브젝트를 삭제 버튼을 탭해서 삭제 -> 삭제 영역으로 드래그하여 삭제로 변경
    - 오브젝트를 드래그할 때 손가락이 `WhiteboardToolBar`의 `deletionImage`의 `frame`에 들어오고, 이 상태로 손가락을 떼면 삭제하도록 수정했습니다.
    - 이제 버튼이 필요 없어졌기 때문에 `deleteButton`은 삭제했습니다.
    - 아래와 같이 `WhiteboardToolBar`에서 삭제 영역을 얻어올 수 있습니다. `WhiteboardToolBar`에서 `deletionImage`의 좌표를 superView(WhiteboardViewController.view)에서의 frame으로 변환해 return 합니다.
    ```swift
        var deleteZone: CGRect {
            return convert(deletionImage.frame, to: superview)
        }
    ```
- 텍스트 오브젝트 뷰를 선택하면 바로 텍스트 수정을 위해 키보드가 올라오던 현상 수정
    - 텍스트 오브젝트 뷰의 수정 가능 여부를 설정하는 `configureEditable`함수에서 `resignFirstResponder`를 호출해 키보드가 바로 올라오지 않도록 수정했습니다.

- 텍스트 편집 시 키보드가 삭제 버튼과 다른 오브젝트들을 가리던 문제 수정
    - 키보드가 보일 때, transform을 통해 키보드 높이만큼 canvasView를 위로 올렸습니다.
    - 키보드가 내려갈 때, 원복하도록 했습니다.
- TextViewObject에 placeholder 제공
    - 커스텀 TextField와 delegate를 구현했습니다.
    - placeholder를 검은색으로 표시하기 위해 attributedPlaceholder를 사용했습니다.
- 텍스트 편집 시 return 키를 누르지 않아도 텍스트가 편집되도록 수정
    - ViewModel의 input에 추가 case를 넣어서 해결했습니다.
    - 선택 해제를 하면 `view.endEditting(true)`를 통해 view의 first responder 상태를 resign하게 하고 있습니다. 이 과정에서 object의 deselect가 호출되면서 수정하던 내용이 모두 날아가버리는 문제가 있었습니다. (deselect 되면서 textObject가 update 되는데, 이때 변경한 text는 적용되지 않고, `selectedBy` 프로퍼티만 바뀌기 때문)
- UX를 위한 햅틱 반응 추가 
    - 위치, 크기, 각도 수정을 완료할 때 햅틱 반응 (medium)을 유저에게 전달합니다.
    - 오브젝트를 선택후 삭제 영역에 손가락을 드래그하여 옮기면 유저에게 햅틱반응 (heavy)를 전달합니다.
