### PR TITLE
[Feature] 화이트보드 입장 핸들링

### DIFF
--- a/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
+++ b/DataSource/DataSource/Sources/Repository/WhiteboardRepository.swift
@@ -12,12 +12,14 @@ import Foundation
 public final class WhiteboardRepository: WhiteboardRepositoryInterface {
     public weak var delegate: WhiteboardRepositoryDelegate?
     public let recentPeerPublisher: AnyPublisher<Profile, Never>
+    public let connectionResultPublisher: AnyPublisher<Bool, Never>
     private var nearbyNetwork: NearbyNetworkInterface
     private var connections: [UUID: NetworkConnection]
     private var participantsInfo: [String: String]
     private let decoder = JSONDecoder()
     private var myProfile: Profile
     private var recentPeerSubject = PassthroughSubject<Profile, Never>()
+    private var connectionResultSubject = PassthroughSubject<Bool, Never>()
 
     public init(nearbyNetworkInterface: NearbyNetworkInterface, myProfile: Profile) {
         self.nearbyNetwork = nearbyNetworkInterface
@@ -25,6 +27,7 @@ public final class WhiteboardRepository: WhiteboardRepositoryInterface {
         self.connections = [:]
         self.myProfile = myProfile
         self.recentPeerPublisher = recentPeerSubject.eraseToAnyPublisher()
+        self.connectionResultPublisher = connectionResultSubject.eraseToAnyPublisher()
         self.nearbyNetwork.connectionDelegate = self
     }
 
@@ -139,6 +142,7 @@ extension WhiteboardRepository: NearbyNetworkConnectionDelegate {
         with context: Data?,
         isHost: Bool
     ) {
+        connectionResultSubject.send(true)
         do {
             guard
                 isHost,

--- a/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
+++ b/Domain/Domain/Sources/Interface/Repository/WhiteboardRepositoryInterface.swift
@@ -10,6 +10,7 @@ import Foundation
 public protocol WhiteboardRepositoryInterface {
     var delegate: WhiteboardRepositoryDelegate? { get set }
     var recentPeerPublisher: AnyPublisher<Profile, Never> { get }
+    var connectionResultPublisher: AnyPublisher<Bool, Never> { get }
 
     /// 주변에 내 기기를 참여자의 아이콘 정보와 함께 화이트보드를 알립니다.
     /// - Parameter myProfile: 나의 프로필

--- a/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
+++ b/Domain/Domain/Sources/Interface/UseCase/WhiteboardUseCaseInterface.swift
@@ -9,6 +9,7 @@ import Combine
 
 public protocol WhiteboardUseCaseInterface {
     var whiteboardListPublisher: AnyPublisher<[Whiteboard], Never> { get }
+    var whiteboardConnectionPublisher: AnyPublisher<Bool, Never> { get }
 
     /// 화이트보드를 생성합니다.
     func createWhiteboard() -> Whiteboard

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -13,7 +13,7 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     private var profileRepository: ProfileRepositoryInterface
     private let whiteboardListSubject: CurrentValueSubject<[Whiteboard], Never>
     public let whiteboardListPublisher: AnyPublisher<[Whiteboard], Never>
-    public let whiteboardConnectionSubject: PassthroughSubject<Bool, Never>
+    private let whiteboardConnectionSubject: PassthroughSubject<Bool, Never>
     public let whiteboardConnectionPublisher: AnyPublisher<Bool, Never>
     private var cancellables: Set<AnyCancellable>
 

--- a/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
+++ b/Domain/Domain/Sources/UseCase/WhiteboardUseCase.swift
@@ -13,6 +13,9 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
     private var profileRepository: ProfileRepositoryInterface
     private let whiteboardListSubject: CurrentValueSubject<[Whiteboard], Never>
     public let whiteboardListPublisher: AnyPublisher<[Whiteboard], Never>
+    public let whiteboardConnectionSubject: PassthroughSubject<Bool, Never>
+    public let whiteboardConnectionPublisher: AnyPublisher<Bool, Never>
+    private var cancellables: Set<AnyCancellable>
 
     public init(
         whiteboardRepository: WhiteboardRepositoryInterface,
@@ -22,6 +25,9 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
         self.profileRepository = profileRepository
         whiteboardListSubject = CurrentValueSubject<[Whiteboard], Never>([])
         whiteboardListPublisher = whiteboardListSubject.eraseToAnyPublisher()
+        whiteboardConnectionSubject = PassthroughSubject<Bool, Never>()
+        whiteboardConnectionPublisher = whiteboardConnectionSubject.eraseToAnyPublisher()
+        cancellables = []
         self.whiteboardRepository.delegate = self
     }
 
@@ -48,11 +54,27 @@ public final class WhiteboardUseCase: WhiteboardUseCaseInterface {
 
     public func joinWhiteboard(whiteboard: Whiteboard) throws {
         let profile = profileRepository.loadProfile()
+        bindConnectionResult()
         try whiteboardRepository.joinWhiteboard(whiteboard: whiteboard, myProfile: profile)
     }
 
     public func startSearchingWhiteboards() {
         whiteboardRepository.startSearching()
+    }
+
+    private func bindConnectionResult() {
+        whiteboardRepository.connectionResultPublisher
+            .timeout(.seconds(3), scheduler: DispatchQueue.main)
+            .first()
+            .replaceEmpty(with: false)
+            .sink { [weak self] isConnected in
+                if isConnected {
+                    self?.whiteboardConnectionSubject.send(true)
+                } else {
+                    self?.whiteboardConnectionSubject.send(false)
+                }
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
+++ b/Domain/DomainTests/ManageWhiteboardObjectsUseCaseTests.swift
@@ -453,12 +453,16 @@ final class MockWhiteObjectRepository: WhiteboardObjectRepositoryInterface {
 }
 
 final class MockWhiteboardRepository: WhiteboardRepositoryInterface {
+    
     var delegate: (any WhiteboardRepositoryDelegate)?
     var recentPeerPublisher: AnyPublisher<Domain.Profile, Never>
+    var connectionResultPublisher: AnyPublisher<Bool, Never>
     private var recentPeerSubject = PassthroughSubject<Domain.Profile, Never>()
+    private var connectionResultSubjuect = PassthroughSubject<Bool, Never>()
 
     init() {
         recentPeerPublisher = recentPeerSubject.eraseToAnyPublisher()
+        connectionResultPublisher = connectionResultSubjuect.eraseToAnyPublisher()
     }
 
     func startPublishing(myProfile: Profile) {}

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -305,7 +305,7 @@ public final class WhiteboardListViewController: UIViewController {
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 
-    private func move() {
+    private func moveToWhiteboard() {
         let whiteboardViewModel = WhiteboardViewModel(
             whiteboardUseCase: whiteboardUseCase,
             photoUseCase: photoUseCase,
@@ -350,7 +350,7 @@ public final class WhiteboardListViewController: UIViewController {
             .sink { [weak self] isConnected in
                 self?.stopLoading()
                 if isConnected {
-                    self?.move()
+                    self?.moveToWhiteboard()
                 } else {
                     self?.showFailAlert()
                 }

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -353,6 +353,7 @@ public final class WhiteboardListViewController: UIViewController {
                     self?.moveToWhiteboard()
                 } else {
                     self?.showFailAlert()
+                    self?.viewModel.action(input: .disconnectWhiteboard)
                 }
             }
             .store(in: &cancellables)

--- a/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
+++ b/Presentation/Presentation/Sources/WhiteboardList/View/WhiteboardListViewController.swift
@@ -329,8 +329,7 @@ public final class WhiteboardListViewController: UIViewController {
         let alertController = UIAlertController(
             title: "연결에 실패했습니다",
             message: "화이트보드에 연결할 수 없습니다. 다시 시도해주세요.",
-            preferredStyle: .alert
-        )
+            preferredStyle: .alert)
         let okAction = UIAlertAction(title: "확인", style: .default, handler: nil)
         alertController.addAction(okAction)
         self.present(alertController, animated: true, completion: nil)


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
- 유령 화이트보드 등장에 따른 입장 실패 처리 구현

## 📱 Screenshot
https://github.com/user-attachments/assets/558fd514-ebb3-4ec8-bc0c-f4d373825514

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- 화이트보드 입장 요청 시 로딩 인디케이터 추가
    - 입장 성공 및 실패 응답을 받아올 때 까지(3초)
- 입장 성공 여부에 따른 처리
    - 기기가 연결되면 `WhiteboardRepository`는 연결 성공 여부를 `Bool`값으로 방출합니다. 
    - `WhiteboardUseCase`는 Join 요청 시 일회성 구독을 시작합니다. (다른 참여자가 참가했을 때 값을 받지 않기 위해서)
    - Join 요청이 성공했다면 `WhiteboardViewController`로 진입합니다. 
    - Join 요청이 실패했다면 Alert를 띄웁니다. 

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
유령 화이트 보드를 만드는 방법은 방을 만들고 참여자 입장 후 호스트가 먼저 나가고 참여자가 나가는 것입니다. 
시뮬레이터에선 방이 사라지지만 실기기에서는 사라지지않습니다. 
위에있는 동작 영상 속 첫 번째 셀은 유령 화이트보드로, 연결 시도시 Alert를 띄웁니다. 
두번째 셀은 정상적인 방으로 3초 이내에 연결 요청이 수락되어 입장합니다. 

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- 간혹 유령방인데 연결되는 보드가 있습니다. 안타깝게도 이러한 방에는 대처할 수 없습니다. 
- timeout을 3초로 잡았는데, 이건 논의해볼 필요가 있다고 생각합니다. 
    - 현재 3초가 지나면 `disconnect` 처리하고있습니다. 

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #18 