### PR TITLE
[Refactor] NearbyNetwork 광고, 검색 기능 리팩터링

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -21,7 +21,14 @@ public protocol NearbyNetworkInterface {
 
     /// 주변에 내 기기를 정보와 함께 알립니다.
     /// - Parameter data: 담을 정보
+    @available(*, deprecated, message: "이 메서드는 network framework로 리팩터링 하면서 사용되지 않을 예정입니다.")
     func startPublishing(with info: [String: String])
+
+    /// 주변에 내 기기를 정보와 함께 알립니다.
+    /// - Parameters:
+    ///   - hostName: 호스트의 이름
+    ///   - connectedPeerInfo: 연결된 기기들의 정보
+    func startPublishing(with hostName: String, connectedPeerInfo: [String])
 
     /// 주변에 내 기기 알리는 것을 중지합니다.
     func stopPublishing()
@@ -41,6 +48,7 @@ public protocol NearbyNetworkInterface {
     /// - Parameters:
     ///   - fileURL: 파일의 URL
     ///   - info: 파일에 대한 정보
+    @available(*, deprecated, message: "이 메서드는 network framework로 리팩터링 하면서 사용되지 않을 예정입니다.")
     func send(fileURL: URL, info: DataInformationDTO) async
 
     /// 특정 기기에게 파일을 전송합니다.
@@ -48,6 +56,7 @@ public protocol NearbyNetworkInterface {
     ///   - fileURL: 파일의 URL
     ///   - info: 파일에 대한 정보
     ///   - connection: 전송할 기기 연결 정보
+    @available(*, deprecated, message: "이 메서드는 network framework로 리팩터링 하면서 사용되지 않을 예정입니다.")
     func send(
         fileURL: URL,
         info: DataSource.DataInformationDTO,

--- a/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
+++ b/DataSource/DataSource/Sources/Model/DataInformationDTO.swift
@@ -11,4 +11,14 @@ public struct DataInformationDTO: Codable {
     public let id: UUID
     public let type: AirplaINDataType
     public let isDeleted: Bool
+
+    public init(
+        id: UUID,
+        type: AirplaINDataType,
+        isDeleted: Bool
+    ) {
+        self.id = id
+        self.type = type
+        self.isDeleted = isDeleted
+    }
 }

--- a/DataSource/DataSource/Sources/Model/NetworkConnection.swift
+++ b/DataSource/DataSource/Sources/Model/NetworkConnection.swift
@@ -28,3 +28,25 @@ extension NetworkConnection: Equatable {
         return lhs.id == rhs.id
     }
 }
+
+public struct RefactoredNetworkConnection: Codable {
+    public let id: UUID
+    public let name: String
+    public let connectedPeerInfo: [String]
+
+    public init(
+        id: UUID,
+        name: String,
+        connectedPeerInfo: [String]
+    ) {
+        self.id = id
+        self.name = name
+        self.connectedPeerInfo = connectedPeerInfo
+    }
+}
+
+extension RefactoredNetworkConnection: Equatable {
+    public static func == (lhs: RefactoredNetworkConnection, rhs: RefactoredNetworkConnection) -> Bool {
+        return lhs.id == rhs.id
+    }
+}

--- a/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
+++ b/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */; };
 		5B7C6EBF2CDB6C6E0024704A /* DataSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EBE2CDB6C6E0024704A /* DataSource.framework */; };
 		5B7C6EC02CDB6C6E0024704A /* DataSource.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6EBE2CDB6C6E0024704A /* DataSource.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A83D2AB02D23BAFC007EC41F /* NearbyNetworkListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D2AAF2D23BAFC007EC41F /* NearbyNetworkListener.swift */; };
+		A83D2AB22D23BE88007EC41F /* NearbyNetworkBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D2AB12D23BE88007EC41F /* NearbyNetworkBrowser.swift */; };
+		A83D2AB42D23C09F007EC41F /* NearbyNetworkKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D2AB32D23C09F007EC41F /* NearbyNetworkKey.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -36,6 +39,9 @@
 		0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkService.swift; sourceTree = "<group>"; };
 		5B7C6E652CDB6A560024704A /* NearbyNetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NearbyNetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B7C6EBE2CDB6C6E0024704A /* DataSource.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DataSource.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A83D2AAF2D23BAFC007EC41F /* NearbyNetworkListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkListener.swift; sourceTree = "<group>"; };
+		A83D2AB12D23BE88007EC41F /* NearbyNetworkBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkBrowser.swift; sourceTree = "<group>"; };
+		A83D2AB32D23C09F007EC41F /* NearbyNetworkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkKey.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +79,9 @@
 				00549AD32CEDDDA300DF8F6C /* Common */,
 				0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */,
 				002DEC942D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift */,
+				A83D2AAF2D23BAFC007EC41F /* NearbyNetworkListener.swift */,
+				A83D2AB32D23C09F007EC41F /* NearbyNetworkKey.swift */,
+				A83D2AB12D23BE88007EC41F /* NearbyNetworkBrowser.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -215,10 +224,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A83D2AB22D23BE88007EC41F /* NearbyNetworkBrowser.swift in Sources */,
 				00549AD62CEDDDB700DF8F6C /* MCSessionState+.swift in Sources */,
+				A83D2AB02D23BAFC007EC41F /* NearbyNetworkListener.swift in Sources */,
 				00549AD82CEDDDCF00DF8F6C /* MCSession+.swift in Sources */,
 				002DEC952D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift in Sources */,
 				0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */,
+				A83D2AB42D23C09F007EC41F /* NearbyNetworkKey.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
+++ b/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		002DEC952D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002DEC942D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift */; };
+		002DEC9D2D23C33C00ED7EE3 /* NearbyNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002DEC9C2D23C33C00ED7EE3 /* NearbyNetworkTests.swift */; };
+		002DEC9E2D23C33C00ED7EE3 /* NearbyNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7C6E652CDB6A560024704A /* NearbyNetwork.framework */; platformFilter = ios; };
 		00549AD62CEDDDB700DF8F6C /* MCSessionState+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */; };
 		00549AD82CEDDDCF00DF8F6C /* MCSession+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */; };
 		0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */; };
@@ -17,6 +19,16 @@
 		A83D2AB22D23BE88007EC41F /* NearbyNetworkBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D2AB12D23BE88007EC41F /* NearbyNetworkBrowser.swift */; };
 		A83D2AB42D23C09F007EC41F /* NearbyNetworkKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83D2AB32D23C09F007EC41F /* NearbyNetworkKey.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		002DEC9F2D23C33C00ED7EE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B7C6E5C2CDB6A560024704A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B7C6E642CDB6A560024704A;
+			remoteInfo = NearbyNetwork;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		5B7C6EC12CDB6C6E0024704A /* Embed Frameworks */ = {
@@ -34,6 +46,8 @@
 
 /* Begin PBXFileReference section */
 		002DEC942D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefactoredNearbyNetworkService.swift; sourceTree = "<group>"; };
+		002DEC9A2D23C33C00ED7EE3 /* NearbyNetworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NearbyNetworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		002DEC9C2D23C33C00ED7EE3 /* NearbyNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkTests.swift; sourceTree = "<group>"; };
 		00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSessionState+.swift"; sourceTree = "<group>"; };
 		00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSession+.swift"; sourceTree = "<group>"; };
 		0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkService.swift; sourceTree = "<group>"; };
@@ -45,6 +59,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		002DEC972D23C33C00ED7EE3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				002DEC9E2D23C33C00ED7EE3 /* NearbyNetwork.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B7C6E622CDB6A560024704A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -56,6 +78,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		002DEC9B2D23C33C00ED7EE3 /* NearbyNetworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				002DEC9C2D23C33C00ED7EE3 /* NearbyNetworkTests.swift */,
+			);
+			path = NearbyNetworkTests;
+			sourceTree = "<group>";
+		};
 		00549AD32CEDDDA300DF8F6C /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -98,6 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				0080E8692CE19EC40095B958 /* NearbyNetwork */,
+				002DEC9B2D23C33C00ED7EE3 /* NearbyNetworkTests */,
 				5B7C6EBD2CDB6C6E0024704A /* Frameworks */,
 				5B7C6E662CDB6A560024704A /* Products */,
 			);
@@ -107,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				5B7C6E652CDB6A560024704A /* NearbyNetwork.framework */,
+				002DEC9A2D23C33C00ED7EE3 /* NearbyNetworkTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -132,6 +164,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		002DEC992D23C33C00ED7EE3 /* NearbyNetworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 002DECA32D23C33C00ED7EE3 /* Build configuration list for PBXNativeTarget "NearbyNetworkTests" */;
+			buildPhases = (
+				002DEC962D23C33C00ED7EE3 /* Sources */,
+				002DEC972D23C33C00ED7EE3 /* Frameworks */,
+				002DEC982D23C33C00ED7EE3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				002DECA02D23C33C00ED7EE3 /* PBXTargetDependency */,
+			);
+			name = NearbyNetworkTests;
+			productName = NearbyNetworkTests;
+			productReference = 002DEC9A2D23C33C00ED7EE3 /* NearbyNetworkTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		5B7C6E642CDB6A560024704A /* NearbyNetwork */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5B7C6E6B2CDB6A560024704A /* Build configuration list for PBXNativeTarget "NearbyNetwork" */;
@@ -161,8 +211,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
+					002DEC992D23C33C00ED7EE3 = {
+						CreatedOnToolsVersion = 15.4;
+					};
 					5B7C6E642CDB6A560024704A = {
 						CreatedOnToolsVersion = 16.0;
 						LastSwiftMigration = 1600;
@@ -184,11 +238,19 @@
 			projectRoot = "";
 			targets = (
 				5B7C6E642CDB6A560024704A /* NearbyNetwork */,
+				002DEC992D23C33C00ED7EE3 /* NearbyNetworkTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		002DEC982D23C33C00ED7EE3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B7C6E632CDB6A560024704A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -220,6 +282,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		002DEC962D23C33C00ED7EE3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				002DEC9D2D23C33C00ED7EE3 /* NearbyNetworkTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5B7C6E612CDB6A560024704A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -236,7 +306,50 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		002DECA02D23C33C00ED7EE3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 5B7C6E642CDB6A560024704A /* NearbyNetwork */;
+			targetProxy = 002DEC9F2D23C33C00ED7EE3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		002DECA12D23C33C00ED7EE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = VKW8W27KRV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.NearbyNetworkTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		002DECA22D23C33C00ED7EE3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = VKW8W27KRV;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp9.NearbyNetworkTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		5B7C6E6C2CDB6A560024704A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -446,6 +559,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		002DECA32D23C33C00ED7EE3 /* Build configuration list for PBXNativeTarget "NearbyNetworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				002DECA12D23C33C00ED7EE3 /* Debug */,
+				002DECA22D23C33C00ED7EE3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		5B7C6E5F2CDB6A560024704A /* Build configuration list for PBXProject "NearbyNetwork" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
+++ b/NearbyNetwork/NearbyNetwork.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		002DEC952D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002DEC942D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift */; };
 		00549AD62CEDDDB700DF8F6C /* MCSessionState+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */; };
 		00549AD82CEDDDCF00DF8F6C /* MCSession+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */; };
 		0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		002DEC942D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefactoredNearbyNetworkService.swift; sourceTree = "<group>"; };
 		00549AD52CEDDDB100DF8F6C /* MCSessionState+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSessionState+.swift"; sourceTree = "<group>"; };
 		00549AD72CEDDDCF00DF8F6C /* MCSession+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MCSession+.swift"; sourceTree = "<group>"; };
 		0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyNetworkService.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 			children = (
 				00549AD32CEDDDA300DF8F6C /* Common */,
 				0080E8672CE19EC40095B958 /* NearbyNetworkService.swift */,
+				002DEC942D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 			files = (
 				00549AD62CEDDDB700DF8F6C /* MCSessionState+.swift in Sources */,
 				00549AD82CEDDDCF00DF8F6C /* MCSession+.swift in Sources */,
+				002DEC952D22A99F00ED7EE3 /* RefactoredNearbyNetworkService.swift in Sources */,
 				0080E86A2CE19EC40095B958 /* NearbyNetworkService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NearbyNetwork/NearbyNetwork.xcodeproj/xcshareddata/xcschemes/NearbyNetwork.xcscheme
+++ b/NearbyNetwork/NearbyNetwork.xcodeproj/xcshareddata/xcschemes/NearbyNetwork.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B7C6E642CDB6A560024704A"
+               BuildableName = "NearbyNetwork.framework"
+               BlueprintName = "NearbyNetwork"
+               ReferencedContainer = "container:NearbyNetwork.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "002DEC992D23C33C00ED7EE3"
+               BuildableName = "NearbyNetworkTests.xctest"
+               BlueprintName = "NearbyNetworkTests"
+               ReferencedContainer = "container:NearbyNetwork.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B7C6E642CDB6A560024704A"
+            BuildableName = "NearbyNetwork.framework"
+            BlueprintName = "NearbyNetwork"
+            ReferencedContainer = "container:NearbyNetwork.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NearbyNetwork/NearbyNetwork.xcodeproj/xcshareddata/xcschemes/NearbyNetworkTests.xcscheme
+++ b/NearbyNetwork/NearbyNetwork.xcodeproj/xcshareddata/xcschemes/NearbyNetworkTests.xcscheme
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "002DEC992D23C33C00ED7EE3"
+               BuildableName = "NearbyNetworkTests.xctest"
+               BlueprintName = "NearbyNetworkTests"
+               ReferencedContainer = "container:NearbyNetwork.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B25A3E32CDB68E500CB7B34"
+            BuildableName = "AirplaIN.app"
+            BlueprintName = "AirplaIN"
+            ReferencedContainer = "container:../AirplaIN/AirplaIN.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
@@ -1,0 +1,51 @@
+//
+//  NearbyNetworkBrowser.swift
+//  NearbyNetwork
+//
+//  Created by 최정인 on 12/31/24.
+//
+
+import Foundation
+import Network
+import OSLog
+
+final class NearbyNetworkBrowser {
+    let nwBrowser: NWBrowser
+    private let browserQueue: DispatchQueue
+    private let serviceType: String
+    private let logger: Logger
+
+    init(serviceType: String) {
+        nwBrowser = NWBrowser(
+            for: .bonjourWithTXTRecord(type: serviceType, domain: nil),
+            using: .tcp)
+        self.browserQueue = DispatchQueue.global()
+        self.serviceType = serviceType
+        self.logger = Logger()
+        configure()
+    }
+
+    private func configure() {
+        nwBrowser.browseResultsChangedHandler = browserHandler
+    }
+
+    private func browserHandler(results: Set<NWBrowser.Result>, changes: Set<NWBrowser.Result.Change>) {
+        for result in results {
+            switch result.metadata {
+            case .bonjour(let foundedPeerData):
+                // TODO: - 추후 발견한 데이터 이용
+                print("")
+            default:
+                logger.log(level: .error, "알 수 없는 피어가 발견되었습니다.")
+            }
+        }
+    }
+
+    func startSearching() {
+        nwBrowser.start(queue: browserQueue)
+    }
+
+    func stopSearching() {
+        nwBrowser.cancel()
+    }
+}

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
@@ -17,7 +17,7 @@ public protocol NearbyNetworkBrowserDelegate: AnyObject {
 }
 
 public final class NearbyNetworkBrowser {
-    let nwBrowser: NWBrowser
+    private let nwBrowser: NWBrowser
     private let browserQueue: DispatchQueue
     private let serviceType: String
     private let logger: Logger

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
@@ -9,11 +9,19 @@ import Foundation
 import Network
 import OSLog
 
-final class NearbyNetworkBrowser {
+public protocol NearbyNetworkBrowserDelegate: AnyObject {
+    func nearbyNetworkBrowserDidFindPeer(
+        _ sender: NearbyNetworkBrowser,
+        hostName: String,
+        connectedPeerInfo: [String])
+}
+
+public final class NearbyNetworkBrowser {
     let nwBrowser: NWBrowser
     private let browserQueue: DispatchQueue
     private let serviceType: String
     private let logger: Logger
+    weak var delegate: NearbyNetworkBrowserDelegate?
 
     init(serviceType: String) {
         nwBrowser = NWBrowser(
@@ -33,8 +41,21 @@ final class NearbyNetworkBrowser {
         for result in results {
             switch result.metadata {
             case .bonjour(let foundedPeerData):
-                // TODO: - 추후 발견한 데이터 이용
-                print("")
+                let dictionary = foundedPeerData.dictionary
+                guard
+                    let hostName = dictionary[NearbyNetworkKey.host.rawValue],
+                    let connectedPeerInfo = dictionary[NearbyNetworkKey.connectedPeerInfo.rawValue]
+                else {
+                    logger.log(level: .error, "connection의 데이터 값이 유효하지 않습니다.")
+                    return
+                }
+
+                delegate?.nearbyNetworkBrowserDidFindPeer(
+                        self,
+                        hostName: hostName,
+                        connectedPeerInfo: connectedPeerInfo
+                            .split(separator: ",")
+                            .map { String($0) })
             default:
                 logger.log(level: .error, "알 수 없는 피어가 발견되었습니다.")
             }

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkKey.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkKey.swift
@@ -1,0 +1,11 @@
+//
+//  NearbyNetworkKey.swift
+//  NearbyNetwork
+//
+//  Created by 최정인 on 12/31/24.
+//
+
+enum NearbyNetworkKey: String {
+    case host
+    case connectedPeerInfo
+}

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkKey.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkKey.swift
@@ -5,7 +5,7 @@
 //  Created by 최정인 on 12/31/24.
 //
 
-enum NearbyNetworkKey: String {
+public enum NearbyNetworkKey: String {
     case host
     case connectedPeerInfo
 }

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkListener.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkListener.swift
@@ -10,7 +10,7 @@ import Network
 import OSLog
 
 final class NearbyNetworkListener {
-    var nwListener: NWListener?
+    private var nwListener: NWListener?
     private let listenerQueue: DispatchQueue
     private let serviceName: String
     private let serviceType: String

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkListener.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkListener.swift
@@ -1,0 +1,62 @@
+//
+//  NearbyNetworkListener.swift
+//  NearbyNetwork
+//
+//  Created by 최정인 on 12/31/24.
+//
+
+import Foundation
+import Network
+import OSLog
+
+final class NearbyNetworkListener {
+    var nwListener: NWListener?
+    private let listenerQueue: DispatchQueue
+    private let serviceName: String
+    private let serviceType: String
+    private let logger: Logger
+
+    init(serviceName: String, serviceType: String) {
+        nwListener = try? NWListener(using: .tcp)
+        listenerQueue = DispatchQueue.global()
+        self.serviceName = serviceName
+        self.serviceType = serviceType
+        self.logger = Logger()
+        configure()
+    }
+
+    private func configure() {
+        nwListener?.newConnectionHandler = { connection in
+            connection.start(queue: self.listenerQueue)
+        }
+    }
+
+    func startPublishing(hostName: String, connectedPeerInfo: [String]) {
+        let connectionData = [
+            NearbyNetworkKey.host.rawValue: hostName,
+            NearbyNetworkKey.connectedPeerInfo.rawValue: connectedPeerInfo.joined(separator: ",")]
+        let txtRecord = NWTXTRecord(connectionData)
+
+        nwListener?.service = NWListener.Service(
+            name: serviceName,
+            type: serviceType,
+            txtRecord: txtRecord)
+
+        nwListener?.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                self.logger.log(level: .debug, "NWListener READY")
+            case .failed(let error):
+                self.logger.log(level: .error, "NWListener Failed \(error.localizedDescription)")
+            default:
+                break
+            }
+        }
+
+        nwListener?.start(queue: listenerQueue)
+    }
+
+    func stopPublishing() {
+        nwListener?.cancel()
+    }
+}

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -76,6 +76,10 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         serviceAdvertiser.startAdvertisingPeer()
     }
 
+    public func startPublishing(with hostName: String, connectedPeerInfo: [String]) {
+        // TODO: - 사용하지 않는 함수
+    }
+
     public func stopPublishing() {
         serviceAdvertiser.stopAdvertisingPeer()
     }

--- a/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
@@ -12,16 +12,17 @@ import Network
 import OSLog
 
 // TODO: - 추후 기능 동작 확인 후 NearbyNetworkService 대체
-final class RefactoredNearbyNetworkService {
-    var connectionDelegate: NearbyNetworkConnectionDelegate? = nil
+public final class RefactoredNearbyNetworkService {
+    public var connectionDelegate: NearbyNetworkConnectionDelegate? = nil
     private let serviceName: String
     private let serviceType: String
     private let peerID: UUID
     private let nearbyNetworkListener: NearbyNetworkListener
     private let nearbyNetworkBrowser: NearbyNetworkBrowser
     private let logger: Logger
+    public var foundPeerHandler: ((_ hostName: String, _ connectedPeerInfo: [String]) -> Void)?
 
-    public init(serviceName: String, serviceType: String) throws {
+    public init(serviceName: String, serviceType: String) {
         peerID = UUID()
         logger = Logger()
         nearbyNetworkListener = NearbyNetworkListener(
@@ -30,15 +31,17 @@ final class RefactoredNearbyNetworkService {
         nearbyNetworkBrowser = NearbyNetworkBrowser(serviceType: serviceType)
         self.serviceName = serviceName
         self.serviceType = serviceType
+        nearbyNetworkBrowser.delegate = self
     }
 }
 
+// MARK: - NearbyNetworkInterface 메서드 구현
 extension RefactoredNearbyNetworkService: NearbyNetworkInterface {
-    var reciptDataPublisher: AnyPublisher<Data, Never> {
+    public var reciptDataPublisher: AnyPublisher<Data, Never> {
         return Just<Data>(Data()).eraseToAnyPublisher()
     }
 
-    var reciptURLPublisher: AnyPublisher<(url: URL, dataInfo: DataInformationDTO), Never> {
+    public var reciptURLPublisher: AnyPublisher<(url: URL, dataInfo: DataInformationDTO), Never> {
         // TODO: - will be deprecated
         guard let url = URL(string: "https://naver.com") else { fatalError() }
         let dataInfo = DataInformationDTO(
@@ -49,45 +52,57 @@ extension RefactoredNearbyNetworkService: NearbyNetworkInterface {
             .eraseToAnyPublisher()
     }
 
-    func startSearching() {
+    public func startSearching() {
         nearbyNetworkBrowser.startSearching()
     }
 
-    func stopSearching() {
+    public func stopSearching() {
         nearbyNetworkBrowser.stopSearching()
     }
 
-    func startPublishing(with info: [String: String]) {
+    public func startPublishing(with info: [String: String]) {
         // TODO: - will be deprecated
     }
 
-    func startPublishing(with hostName: String, connectedPeerInfo: [String]) {
+    public func startPublishing(with hostName: String, connectedPeerInfo: [String]) {
         nearbyNetworkListener.startPublishing(
             hostName: hostName,
             connectedPeerInfo: connectedPeerInfo)
     }
 
-    func stopPublishing() {
+    public func stopPublishing() {
         nearbyNetworkListener.stopPublishing()
     }
 
-    func disconnectAll() {
+    public func disconnectAll() {
 
     }
 
-    func joinConnection(connection: NetworkConnection, context: RequestedContext) throws {
+    public func joinConnection(connection: NetworkConnection, context: RequestedContext) throws {
 
     }
 
-    func send(data: Data) {
+    public func send(data: Data) {
 
     }
 
-    func send(fileURL: URL, info: DataInformationDTO) async {
+    public func send(fileURL: URL, info: DataInformationDTO) async {
         // TODO: - will be deprecated
     }
 
-    func send(fileURL: URL, info: DataInformationDTO, to connection: NetworkConnection) async {
+    public func send(fileURL: URL, info: DataInformationDTO, to connection: NetworkConnection) async {
         // TODO: - will be deprecated
+    }
+}
+
+// MARK: - NearbyNetworkBrowserDelegate
+extension RefactoredNearbyNetworkService: NearbyNetworkBrowserDelegate {
+    public func nearbyNetworkBrowserDidFindPeer(
+        _ sender: NearbyNetworkBrowser,
+        hostName: String,
+        connectedPeerInfo: [String]
+    ) {
+        guard let foundPeerHandler else { return }
+        foundPeerHandler(hostName, connectedPeerInfo)
     }
 }

--- a/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
@@ -1,0 +1,94 @@
+//
+//  RefactoredNearbyNetworkService.swift
+//  NearbyNetwork
+//
+//  Created by 이동현 on 12/30/24.
+//
+
+import Combine
+import DataSource
+import Foundation
+import Network
+
+// TODO: - 추후 기능 동작 확인 후 NearbyNetworkService 대체
+final class RefactoredNearbyNetworkService {
+    var connectionDelegate: NearbyNetworkConnectionDelegate? = nil
+    private let peerID: UUID
+    private let nwListener: NWListener
+    private let networkQueue: DispatchQueue
+
+    public init(serviceName: String) throws {
+        peerID = UUID()
+
+        do {
+            nwListener = try NWListener(using: .tcp)
+            networkQueue = DispatchQueue.global()
+        } catch {
+            throw NSError() // 에러는 추후 정의
+        }
+    }
+}
+
+extension RefactoredNearbyNetworkService: NearbyNetworkInterface {
+    var reciptDataPublisher: AnyPublisher<Data, Never> {
+        return Just<Data>(Data()).eraseToAnyPublisher()
+    }
+    
+    var reciptURLPublisher: AnyPublisher<(url: URL, dataInfo: DataInformationDTO), Never> {
+        // TODO: - will be deprecated
+        guard let url = URL(string: "https://naver.com") else { fatalError() }
+        let dataInfo = DataInformationDTO(
+            id: UUID(),
+            type: .chat,
+            isDeleted: true)
+        return Just<(url: URL, dataInfo: DataInformationDTO)>((url: url, dataInfo: dataInfo))
+            .eraseToAnyPublisher()
+    }
+
+    func stopSearching() {
+
+    }
+
+    func startSearching() {
+
+    }
+
+    func startPublishing(with info: [String: String]) {
+        // TODO: - will be deprecated
+    }
+
+    func startPublishing(with hostName: String, connectedPeerInfo: [String]) {
+        let networkConnection = RefactoredNetworkConnection(
+            id: peerID,
+            name: hostName,
+            connectedPeerInfo: connectedPeerInfo)
+        let serviceData = try? JSONEncoder().encode(networkConnection)
+
+        nwListener.service? = NWListener.Service(type: "_airplain._tcp", txtRecord: serviceData)
+        nwListener.start(queue: networkQueue)
+    }
+
+    func stopPublishing() {
+
+    }
+
+    func disconnectAll() {
+
+    }
+
+    func joinConnection(connection: NetworkConnection, context: RequestedContext) throws {
+
+    }
+
+    func send(data: Data) {
+
+    }
+
+    func send(fileURL: URL, info: DataInformationDTO) async {
+        // TODO: - will be deprecated
+    }
+
+    func send(fileURL: URL, info: DataInformationDTO, to connection: NetworkConnection) async {
+        // TODO: - will be deprecated
+    }
+}

--- a/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
@@ -69,7 +69,7 @@ extension RefactoredNearbyNetworkService: NearbyNetworkInterface {
     }
 
     func stopPublishing() {
-
+        nwListener.cancel()
     }
 
     func disconnectAll() {

--- a/NearbyNetwork/NearbyNetworkTests/NearbyNetworkTests.swift
+++ b/NearbyNetwork/NearbyNetworkTests/NearbyNetworkTests.swift
@@ -1,0 +1,118 @@
+//
+//  NearbyNetworkTests.swift
+//  NearbyNetworkTests
+//
+//  Created by 이동현 on 12/31/24.
+//
+
+import NearbyNetwork
+import Network
+import XCTest
+
+final class NearbyNetworkTests: XCTestCase {
+    var nearbyNetworkService: RefactoredNearbyNetworkService?
+
+    override func setUpWithError() throws {
+        nearbyNetworkService = RefactoredNearbyNetworkService(
+            serviceName: "airplain",
+            serviceType: "_airplain._tcp")
+    }
+
+    override func tearDownWithError() throws {
+        nearbyNetworkService = nil
+    }
+
+    func testAdvertisingSuccess() {
+        // 준비
+        let expectedHostName = "host"
+        let expectedConnectedPeerInfo = ["1", "2", "3"]
+        let serviceType = "_airplain._tcp"
+        let browserQueue = DispatchQueue.global()
+        let browser = NWBrowser(
+            for: .bonjourWithTXTRecord(type: serviceType, domain: nil),
+            using: .tcp)
+        let browsingExpectation = XCTestExpectation(description: "검색 성공 여부")
+        var browsedHostName: String?
+        var browsedPeerInfo: String?
+
+        // 실행
+        XCTAssertNotNil(nearbyNetworkService)
+        nearbyNetworkService?.startPublishing(
+            with: expectedHostName,
+            connectedPeerInfo: expectedConnectedPeerInfo)
+
+        browser.start(queue: browserQueue)
+        browser.browseResultsChangedHandler = { results, _ in
+            for result in results {
+                switch result.metadata {
+                case .bonjour(let foundedPeerData):
+                    browsedHostName = foundedPeerData.dictionary[NearbyNetworkKey.host.rawValue]
+                    browsedPeerInfo = foundedPeerData.dictionary[NearbyNetworkKey.connectedPeerInfo.rawValue]
+                    browsingExpectation.fulfill()
+                default:
+                    break
+                }
+                break
+            }
+        }
+        wait(for: [browsingExpectation], timeout: 3)
+
+        // 검증
+        guard
+            let browsedHostName,
+            let browsedPeerInfo
+        else {
+            XCTFail("browsedHostName, browsedPeerInfo가 정상적으로 초기화되지 않았습니다.")
+            return
+        }
+
+        XCTAssertEqual(expectedHostName, browsedHostName)
+        XCTAssertEqual(expectedConnectedPeerInfo.joined(separator: ","), browsedPeerInfo)
+    }
+
+    func testBrowsingSuccess() {
+        // 준비
+        let expectedHostName = "host"
+        let expectedConnectedPeerInfo = ["1", "2", "3"]
+        let txtRecord = NWTXTRecord([
+            NearbyNetworkKey.host.rawValue: expectedHostName,
+            NearbyNetworkKey.connectedPeerInfo.rawValue: expectedConnectedPeerInfo.joined(separator: ",")
+        ])
+        guard let advertiser = try? NWListener(using: .tcp) else {
+            XCTFail("advertiser 생성 실패")
+            return
+        }
+        let advertiserQueue = DispatchQueue.global()
+        let advertisingExpectation = XCTestExpectation(description: "광고 성공 여부")
+        var advertisingHostName: String?
+        var advertisingPeerInfo: [String]?
+        let foundPeerHandler: (String, [String]) -> Void = { hostName, connectedPeerInfo in
+            advertisingHostName = hostName
+            advertisingPeerInfo = connectedPeerInfo
+            advertisingExpectation.fulfill()
+        }
+        nearbyNetworkService?.foundPeerHandler = foundPeerHandler
+        advertiser.newConnectionHandler = { _ in }
+        advertiser.service = NWListener.Service(
+            name: "airplain",
+            type: "_airplain._tcp",
+            txtRecord: txtRecord)
+
+        // 실행
+        advertiser.start(queue: advertiserQueue)
+        nearbyNetworkService?.startSearching()
+        wait(for: [advertisingExpectation], timeout: 3)
+
+        // 검증
+        guard
+            let advertisingHostName,
+            let advertisingPeerInfo
+        else {
+            XCTFail("advertisingHostName, advertisingPeerInfo가 정상적으로 초기화되지 않았습니다.")
+            return
+        }
+
+        XCTAssertEqual(expectedHostName, advertisingHostName)
+        XCTAssertEqual(expectedConnectedPeerInfo, advertisingPeerInfo)
+    }
+}


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->

MPC Framework를 Network Framework로 교체 작업을 시작하였습니다.    

다음과 같은 순서로 리팩터링 진행 예정입니다.
1. 광고
2. 검색
3. 참여
4. 데이터 송신
5. 데이터 수신


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->

이번 PR에서는 2번까지 작업 완료하였습니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
NearbyNetworkTest를 통해 광고, 검색을 테스트 하였습니다.   


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

Browsing을 테스트 하기 위해 NearbyNetworkService의 구조를 변경했습니다. 
검색된 connection에 대한 정보를 검증하기 위해 NearbyNetworkService에 foundPeerHandler를 추가하였습니다.     
추후 참여 구현 과정에서 수정될 수 있습니다.  

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #143 
- close #144 
