### PR TITLE
[Feature] 화이트보드 오브젝트의 실시간 데이터 일관성을 보장하기 위한 레지스터 구현

### DIFF
--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		6F5FC15C2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC15B2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift */; };
 		6F68E7852CEC200000945394 /* TextObjectUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7842CEC200000945394 /* TextObjectUseCase.swift */; };
 		6F68E7872CEC593300945394 /* TextObjectUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */; };
+		6F6A89A72D2E9367008CF899 /* LWWRegisterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6A89A62D2E9367008CF899 /* LWWRegisterTests.swift */; };
 		A81E7BF32CF70C17007E8414 /* GameObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BF22CF70C17007E8414 /* GameObject.swift */; };
 		A81E7BF92CF72503007E8414 /* GameObjectUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BF82CF72503007E8414 /* GameObjectUseCase.swift */; };
 		A81E7BFB2CF725C2007E8414 /* GameObjectUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BFA2CF725C2007E8414 /* GameObjectUseCaseInterface.swift */; };
@@ -109,6 +110,7 @@
 		6F5FC15B2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectRegistersInterface.swift; sourceTree = "<group>"; };
 		6F68E7842CEC200000945394 /* TextObjectUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCase.swift; sourceTree = "<group>"; };
 		6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseTests.swift; sourceTree = "<group>"; };
+		6F6A89A62D2E9367008CF899 /* LWWRegisterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LWWRegisterTests.swift; sourceTree = "<group>"; };
 		A81E7BF22CF70C17007E8414 /* GameObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameObject.swift; sourceTree = "<group>"; };
 		A81E7BF82CF72503007E8414 /* GameObjectUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameObjectUseCase.swift; sourceTree = "<group>"; };
 		A81E7BFA2CF725C2007E8414 /* GameObjectUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameObjectUseCaseInterface.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */,
 				007BCEDB2CEB852C009E6935 /* AddPhotoUseCaseTests.swift */,
 				6F3BCDD12CF45510005F6642 /* ChatUseCaseTests.swift */,
+				6F6A89A62D2E9367008CF899 /* LWWRegisterTests.swift */,
 			);
 			path = DomainTests;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				007BCEDC2CEB852C009E6935 /* AddPhotoUseCaseTests.swift in Sources */,
+				6F6A89A72D2E9367008CF899 /* LWWRegisterTests.swift in Sources */,
 				6F3BCDD22CF45510005F6642 /* ChatUseCaseTests.swift in Sources */,
 				00D2DD952CE88EDA0089F0BA /* ManageWhiteboardObjectsUseCaseTests.swift in Sources */,
 				0080E9582CE4D8760095B958 /* DrawObjectUseCaseTests.swift in Sources */,

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */; };
 		6F5FC1562D2BF5100049A44F /* LWWRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC1552D2BF5100049A44F /* LWWRegister.swift */; };
 		6F5FC1582D2BF51E0049A44F /* Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC1572D2BF51E0049A44F /* Timestamp.swift */; };
+		6F5FC15A2D2C1BFF0049A44F /* WhiteboardObjectRegisters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC1592D2C1BFF0049A44F /* WhiteboardObjectRegisters.swift */; };
+		6F5FC15C2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC15B2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift */; };
 		6F68E7852CEC200000945394 /* TextObjectUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7842CEC200000945394 /* TextObjectUseCase.swift */; };
 		6F68E7872CEC593300945394 /* TextObjectUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */; };
 		A81E7BF32CF70C17007E8414 /* GameObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BF22CF70C17007E8414 /* GameObject.swift */; };
@@ -103,6 +105,8 @@
 		6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseInterface.swift; sourceTree = "<group>"; };
 		6F5FC1552D2BF5100049A44F /* LWWRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LWWRegister.swift; sourceTree = "<group>"; };
 		6F5FC1572D2BF51E0049A44F /* Timestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timestamp.swift; sourceTree = "<group>"; };
+		6F5FC1592D2C1BFF0049A44F /* WhiteboardObjectRegisters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectRegisters.swift; sourceTree = "<group>"; };
+		6F5FC15B2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardObjectRegistersInterface.swift; sourceTree = "<group>"; };
 		6F68E7842CEC200000945394 /* TextObjectUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCase.swift; sourceTree = "<group>"; };
 		6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseTests.swift; sourceTree = "<group>"; };
 		A81E7BF22CF70C17007E8414 /* GameObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameObject.swift; sourceTree = "<group>"; };
@@ -201,6 +205,7 @@
 				0080E9192CE4B0880095B958 /* UseCase */,
 				0080E8CC2CE446270095B958 /* Repository */,
 				00036B852CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift */,
+				6F5FC15B2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -252,6 +257,7 @@
 			children = (
 				6F5FC1572D2BF51E0049A44F /* Timestamp.swift */,
 				6F5FC1552D2BF5100049A44F /* LWWRegister.swift */,
+				6F5FC1592D2C1BFF0049A44F /* WhiteboardObjectRegisters.swift */,
 				00D2DD8E2CE88C640089F0BA /* WhiteboardTool.swift */,
 				005BCC502CF01D29001B3623 /* WhiteboardObjectSet.swift */,
 			);
@@ -440,6 +446,7 @@
 				A8E97C052CE5E3AB00B28063 /* ProfileUseCaseInterface.swift in Sources */,
 				004B217D2CEB2B2300A5BEB8 /* DomainError.swift in Sources */,
 				6F3BCDC82CF31CB4005F6642 /* ChatMessage.swift in Sources */,
+				6F5FC15C2D2C1CF80049A44F /* WhiteboardObjectRegistersInterface.swift in Sources */,
 				005BCC512CF01D29001B3623 /* WhiteboardObjectSet.swift in Sources */,
 				A8E97BDB2CE5A6D500B28063 /* ProfileRepositoryInterface.swift in Sources */,
 				A8E97BD92CE5A6B800B28063 /* ProfileIcon.swift in Sources */,
@@ -462,6 +469,7 @@
 				A81E7C012CF72A4C007E8414 /* GameRepositoryInterface.swift in Sources */,
 				6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */,
 				00D2DD882CE88BD80089F0BA /* ManageWhiteboardToolUseCaseInterface.swift in Sources */,
+				6F5FC15A2D2C1BFF0049A44F /* WhiteboardObjectRegisters.swift in Sources */,
 				003D5A2B2CEB1FF0005F3D09 /* PhotoObject.swift in Sources */,
 				6F3BCDCA2CF31DBA005F6642 /* ChatRepositoryInterface.swift in Sources */,
 				0080E8CE2CE4463B0095B958 /* WhiteboardObjectRepositoryInterface.swift in Sources */,

--- a/Domain/Domain.xcodeproj/project.pbxproj
+++ b/Domain/Domain.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		6F3BCDD02CF3322C005F6642 /* ChatUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3BCDCF2CF3322C005F6642 /* ChatUseCase.swift */; };
 		6F3BCDD22CF45510005F6642 /* ChatUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3BCDD12CF45510005F6642 /* ChatUseCaseTests.swift */; };
 		6F47898F2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */; };
+		6F5FC1562D2BF5100049A44F /* LWWRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC1552D2BF5100049A44F /* LWWRegister.swift */; };
+		6F5FC1582D2BF51E0049A44F /* Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5FC1572D2BF51E0049A44F /* Timestamp.swift */; };
 		6F68E7852CEC200000945394 /* TextObjectUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7842CEC200000945394 /* TextObjectUseCase.swift */; };
 		6F68E7872CEC593300945394 /* TextObjectUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */; };
 		A81E7BF32CF70C17007E8414 /* GameObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81E7BF22CF70C17007E8414 /* GameObject.swift */; };
@@ -99,6 +101,8 @@
 		6F3BCDCF2CF3322C005F6642 /* ChatUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUseCase.swift; sourceTree = "<group>"; };
 		6F3BCDD12CF45510005F6642 /* ChatUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatUseCaseTests.swift; sourceTree = "<group>"; };
 		6F47898E2CEB8D8F0016B7AB /* TextObjectUseCaseInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseInterface.swift; sourceTree = "<group>"; };
+		6F5FC1552D2BF5100049A44F /* LWWRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LWWRegister.swift; sourceTree = "<group>"; };
+		6F5FC1572D2BF51E0049A44F /* Timestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timestamp.swift; sourceTree = "<group>"; };
 		6F68E7842CEC200000945394 /* TextObjectUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCase.swift; sourceTree = "<group>"; };
 		6F68E7862CEC593300945394 /* TextObjectUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextObjectUseCaseTests.swift; sourceTree = "<group>"; };
 		A81E7BF22CF70C17007E8414 /* GameObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameObject.swift; sourceTree = "<group>"; };
@@ -246,6 +250,8 @@
 		00D2DD962CE8A4DB0089F0BA /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				6F5FC1572D2BF51E0049A44F /* Timestamp.swift */,
+				6F5FC1552D2BF5100049A44F /* LWWRegister.swift */,
 				00D2DD8E2CE88C640089F0BA /* WhiteboardTool.swift */,
 				005BCC502CF01D29001B3623 /* WhiteboardObjectSet.swift */,
 			);
@@ -437,6 +443,7 @@
 				005BCC512CF01D29001B3623 /* WhiteboardObjectSet.swift in Sources */,
 				A8E97BDB2CE5A6D500B28063 /* ProfileRepositoryInterface.swift in Sources */,
 				A8E97BD92CE5A6B800B28063 /* ProfileIcon.swift in Sources */,
+				6F5FC1562D2BF5100049A44F /* LWWRegister.swift in Sources */,
 				00036B862CF58D7C007D1244 /* WhiteboardObjectSetInterface.swift in Sources */,
 				A81E7BF32CF70C17007E8414 /* GameObject.swift in Sources */,
 				A8E97BD82CE5A6B800B28063 /* Profile.swift in Sources */,
@@ -447,6 +454,7 @@
 				6F3BCDD02CF3322C005F6642 /* ChatUseCase.swift in Sources */,
 				5BDFD9342CE1F7DB00DA4F5B /* Whiteboard.swift in Sources */,
 				A81E7BFB2CF725C2007E8414 /* GameObjectUseCaseInterface.swift in Sources */,
+				6F5FC1582D2BF51E0049A44F /* Timestamp.swift in Sources */,
 				5BDFD9372CE2E6BC00DA4F5B /* WhiteboardRepositoryInterface.swift in Sources */,
 				5B6542482CE44631000168AD /* WhiteboardUseCaseInterface.swift in Sources */,
 				00D2DD842CE8864B0089F0BA /* ManageWhiteboardObjectUseCaseInterface.swift in Sources */,

--- a/Domain/Domain/Sources/Interface/WhiteboardObjectRegistersInterface.swift
+++ b/Domain/Domain/Sources/Interface/WhiteboardObjectRegistersInterface.swift
@@ -30,8 +30,8 @@ public protocol WhiteboardObjectRegistersInterface {
 
     /// ID로 집합에있는 레지스터를 가져옵니다.
     /// - Parameter id: 가져올 레지스터의 오브젝트 ID
-    /// - Returns: 레지스터
-    func fetchObjectByID(id: UUID) async -> LWWRegister?
+    /// - Returns: 화이트보드 오브젝트
+    func fetchObjectByID(id: UUID) async -> WhiteboardObject?
 
     /// 모든 화이트보드 오브젝트 레지스터들을 가져옵니다.
     /// - Returns: 화이트보드 레지스터 배열

--- a/Domain/Domain/Sources/Interface/WhiteboardObjectRegistersInterface.swift
+++ b/Domain/Domain/Sources/Interface/WhiteboardObjectRegistersInterface.swift
@@ -1,0 +1,39 @@
+//
+//  WhiteboardObjectRegistersInterface.swift
+//  Domain
+//
+//  Created by 박승찬 on 1/6/25.
+//
+
+import Foundation
+
+public protocol WhiteboardObjectRegistersInterface {
+    /// 집합에 레지스터가 있는지 확인합니다.
+    /// - Parameter register: 확인할 레지스터
+    /// - Returns: 오브젝트 존재 여부
+    func contains(register: LWWRegister) async -> Bool
+
+    /// 집합에 레지스터를 추가합니다.
+    /// - Parameter object: 추가할 레지스터
+    func insert(register: LWWRegister) async
+
+    /// 집합에서 레지스터를 삭제합니다.
+    /// - Parameter register: 삭제할 레지스터
+    func remove(register: LWWRegister) async
+
+    /// 모든 화이트보드 오브젝트 레지스터들을 삭제합니다.
+    func removeAll() async
+
+    /// 집합에 있는 레지스터를 업데이트 합니다.
+    /// - Parameter register: 업데이트할 레지스터
+    func update(register: LWWRegister) async
+
+    /// ID로 집합에있는 레지스터를 가져옵니다.
+    /// - Parameter id: 가져올 레지스터의 오브젝트 ID
+    /// - Returns: 레지스터
+    func fetchObjectByID(id: UUID) async -> LWWRegister?
+
+    /// 모든 화이트보드 오브젝트 레지스터들을 가져옵니다.
+    /// - Returns: 화이트보드 레지스터 배열
+    func fetchAll() async -> [LWWRegister]
+}

--- a/Domain/Domain/Sources/Model/LWWRegister.swift
+++ b/Domain/Domain/Sources/Model/LWWRegister.swift
@@ -7,32 +7,21 @@
 
 import Foundation
 
-public class LWWRegister {
-    private(set) var whiteboardObject: WhiteboardObject
-    private var timestamp: Timestamp
-    private var serialQueue: DispatchQueue
+public struct LWWRegister {
+    public let whiteboardObject: WhiteboardObject
+    private let timestamp: Timestamp
 
-    init(whiteboardObject: WhiteboardObject, timestamp: Timestamp) {
+    public init(whiteboardObject: WhiteboardObject, timestamp: Timestamp) {
         self.whiteboardObject = whiteboardObject
         self.timestamp = timestamp
-        serialQueue = DispatchQueue(label: "serial")
     }
 
-    func merge(register: LWWRegister) {
-        serialQueue.async {
-            if self.timestamp < register.timestamp {
-                self.whiteboardObject = register.whiteboardObject
-                self.timestamp = register.timestamp
-            }
-        }
+    public func merge(register: LWWRegister) -> LWWRegister {
+        timestamp < register.timestamp ? register: self
     }
 }
 
 extension LWWRegister: Hashable {
-    public static func == (lhs: LWWRegister, rhs: LWWRegister) -> Bool {
-        lhs.whiteboardObject == rhs.whiteboardObject
-    }
-
     public func hash(into hasher: inout Hasher) {
         hasher.combine(whiteboardObject)
     }

--- a/Domain/Domain/Sources/Model/LWWRegister.swift
+++ b/Domain/Domain/Sources/Model/LWWRegister.swift
@@ -1,0 +1,20 @@
+//
+//  LWWRegister.swift
+//  Domain
+//
+//  Created by 박승찬 on 1/6/25.
+//
+
+actor LWWRegister {
+    private var whiteboardObject: WhiteboardObject
+    private var timestamp: Timestamp
+
+    init(whiteboardObject: WhiteboardObject, timestamp: Timestamp) {
+        self.whiteboardObject = whiteboardObject
+        self.timestamp = timestamp
+    }
+
+    func merge(with updatedObject: WhiteboardObject, at updatedTimestamp: Timestamp) {
+        if timestamp < updatedTimestamp { whiteboardObject = updatedObject }
+    }
+}

--- a/Domain/Domain/Sources/Model/LWWRegister.swift
+++ b/Domain/Domain/Sources/Model/LWWRegister.swift
@@ -5,16 +5,41 @@
 //  Created by 박승찬 on 1/6/25.
 //
 
-actor LWWRegister {
-    private var whiteboardObject: WhiteboardObject
+import Foundation
+
+public class LWWRegister {
+    private(set) var whiteboardObject: WhiteboardObject
     private var timestamp: Timestamp
+    private var serialQueue: DispatchQueue
 
     init(whiteboardObject: WhiteboardObject, timestamp: Timestamp) {
         self.whiteboardObject = whiteboardObject
         self.timestamp = timestamp
+        serialQueue = DispatchQueue(label: "serial")
     }
 
-    func merge(with updatedObject: WhiteboardObject, at updatedTimestamp: Timestamp) {
-        if timestamp < updatedTimestamp { whiteboardObject = updatedObject }
+    func merge(register: LWWRegister) {
+        serialQueue.async {
+            if self.timestamp < register.timestamp {
+                self.whiteboardObject = register.whiteboardObject
+                self.timestamp = register.timestamp
+            }
+        }
+    }
+}
+
+extension LWWRegister: Hashable {
+    public static func == (lhs: LWWRegister, rhs: LWWRegister) -> Bool {
+        lhs.whiteboardObject == rhs.whiteboardObject
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(whiteboardObject)
+    }
+}
+
+extension LWWRegister: Comparable {
+    public static func < (lhs: LWWRegister, rhs: LWWRegister) -> Bool {
+        lhs.timestamp < rhs.timestamp
     }
 }

--- a/Domain/Domain/Sources/Model/Timestamp.swift
+++ b/Domain/Domain/Sources/Model/Timestamp.swift
@@ -1,0 +1,18 @@
+//
+//  Timestamp.swift
+//  Domain
+//
+//  Created by 박승찬 on 1/6/25.
+//
+
+import Foundation
+
+struct Timestamp: Comparable {
+    let updatedAt: Date
+    let updatedBy: UUID
+
+    static func < (lhs: Timestamp, rhs: Timestamp) -> Bool {
+        if lhs.updatedAt == rhs.updatedAt { return lhs.updatedBy < rhs.updatedBy }
+        return lhs.updatedAt < rhs.updatedAt
+    }
+}

--- a/Domain/Domain/Sources/Model/Timestamp.swift
+++ b/Domain/Domain/Sources/Model/Timestamp.swift
@@ -7,11 +7,16 @@
 
 import Foundation
 
-struct Timestamp: Comparable {
+public struct Timestamp: Comparable {
     let updatedAt: Date
     let updatedBy: UUID
 
-    static func < (lhs: Timestamp, rhs: Timestamp) -> Bool {
+    public init(updatedAt: Date, updatedBy: UUID) {
+        self.updatedAt = updatedAt
+        self.updatedBy = updatedBy
+    }
+
+    public static func < (lhs: Timestamp, rhs: Timestamp) -> Bool {
         if lhs.updatedAt == rhs.updatedAt { return lhs.updatedBy < rhs.updatedBy }
         return lhs.updatedAt < rhs.updatedAt
     }

--- a/Domain/Domain/Sources/Model/WhiteboardObjectRegisters.swift
+++ b/Domain/Domain/Sources/Model/WhiteboardObjectRegisters.swift
@@ -1,0 +1,48 @@
+//
+//  WhiteboardObjectRegisters.swift
+//  Domain
+//
+//  Created by 박승찬 on 1/6/25.
+//
+
+import Foundation
+
+actor WhiteboardObjectRegisters: WhiteboardObjectRegistersInterface {
+    private var registers: Set<LWWRegister>
+
+    init() {
+        registers = []
+    }
+
+    func contains(register: LWWRegister) async -> Bool {
+        registers.contains(register)
+    }
+
+    func insert(register: LWWRegister) async {
+        registers.insert(register)
+    }
+
+    func remove(register: LWWRegister) async {
+        registers.remove(register)
+    }
+
+    func removeAll() async {
+        registers.removeAll()
+    }
+
+    func update(register: LWWRegister) async {
+        guard let targetRegister = registers.first(where: { $0 == register }) else {
+            await insert(register: register)
+            return
+        }
+        targetRegister.merge(register: register)
+    }
+
+    func fetchObjectByID(id: UUID) async -> LWWRegister? {
+        registers.first(where: { $0.whiteboardObject.id == id })
+    }
+
+    func fetchAll() async -> [LWWRegister] {
+        Array(registers.sorted { $0 < $1 })
+    }
+}

--- a/Domain/Domain/Sources/Model/WhiteboardObjectRegisters.swift
+++ b/Domain/Domain/Sources/Model/WhiteboardObjectRegisters.swift
@@ -31,11 +31,12 @@ actor WhiteboardObjectRegisters: WhiteboardObjectRegistersInterface {
     }
 
     func update(register: LWWRegister) async {
-        guard let targetRegister = registers.first(where: { $0 == register }) else {
+        if registers.contains(register) {
+            registers.remove(register)
+            await insert(register: register.merge(register: register))
+        } else {
             await insert(register: register)
-            return
         }
-        targetRegister.merge(register: register)
     }
 
     func fetchObjectByID(id: UUID) async -> LWWRegister? {

--- a/Domain/Domain/Sources/Model/WhiteboardObjectRegisters.swift
+++ b/Domain/Domain/Sources/Model/WhiteboardObjectRegisters.swift
@@ -39,11 +39,16 @@ actor WhiteboardObjectRegisters: WhiteboardObjectRegistersInterface {
         }
     }
 
-    func fetchObjectByID(id: UUID) async -> LWWRegister? {
-        registers.first(where: { $0.whiteboardObject.id == id })
+    func fetchObjectByID(id: UUID) async -> WhiteboardObject? {
+        return registers
+            .first(where: { $0.whiteboardObject.id == id })?
+            .whiteboardObject
+            .deepCopy()
     }
 
     func fetchAll() async -> [LWWRegister] {
-        Array(registers.sorted { $0 < $1 })
+        registers
+            .sorted { $0 < $1 }
+            .map { $0 }
     }
 }

--- a/Domain/DomainTests/LWWRegisterTests.swift
+++ b/Domain/DomainTests/LWWRegisterTests.swift
@@ -1,0 +1,35 @@
+//
+//  LWWRegisterTests.swift
+//  DomainTests
+//
+//  Created by 박승찬 on 1/8/25.
+//
+
+import XCTest
+
+final class LWWRegisterTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Domain/DomainTests/LWWRegisterTests.swift
+++ b/Domain/DomainTests/LWWRegisterTests.swift
@@ -5,31 +5,130 @@
 //  Created by 박승찬 on 1/8/25.
 //
 
+import Domain
 import XCTest
 
 final class LWWRegisterTests: XCTestCase {
+    private var register: LWWRegister!
+    private var defaultTimestamp: Timestamp!
+    private var defaultDate: Date!
+    private var defaultObject: WhiteboardObject!
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    override func setUp() {
+        super.setUp()
+        defaultObject = TextObject(
+            id: UUID(),
+            centerPosition: CGPoint(x: 0, y: 0),
+            size: CGSize(width: 100, height: 100),
+            text: "default")
+        defaultDate = Date()
+        defaultTimestamp = Timestamp(updatedAt: defaultDate, updatedBy: UUID())
+        register = LWWRegister(whiteboardObject: defaultObject, timestamp: defaultTimestamp)
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func tearDown() {
+        register = nil
+        defaultTimestamp = nil
+        defaultDate = nil
+        defaultObject = nil
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    // Timestamp가 같을 때
+    func testMergeWhenEqualTimestmap() {
+        // 준비
+        let textObject = TextObject(
+            id: UUID(),
+            centerPosition: CGPoint(x: 50, y: 50),
+            size: CGSize(width: 200, height: 200),
+            text: "equal")
+        let mockRegister = LWWRegister(whiteboardObject: textObject, timestamp: defaultTimestamp)
+
+        // 실행
+        let sut = register.merge(register: mockRegister)
+
+        // 검증
+        XCTAssertEqual(sut, register)
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    // 새로 들어온 updatedAt이 더 빠를 때
+    func testMergeWhenIncomingTimestampIsEarlier() {
+        // 준비
+        let earlierDate = defaultDate.addingTimeInterval(-10)
+        let earlierTimestamp = Timestamp(updatedAt: earlierDate, updatedBy: UUID())
+        let textObject = TextObject(
+            id: UUID(),
+            centerPosition: CGPoint(x: 50, y: 50),
+            size: CGSize(width: 200, height: 200),
+            text: "incoming")
+        let mockRegister = LWWRegister(whiteboardObject: textObject, timestamp: earlierTimestamp)
+
+        // 실행
+        let sut = register.merge(register: mockRegister)
+
+        // 검증
+        XCTAssertEqual(sut, register)
+    }
+
+    // updatedAt은 같지만 새로 들어온 UUID가 작을 때
+    func testMergeWhenIncomingTimestampHasSmallerUUID() {
+        // 준비
+        guard let smallerUUID = UUID(uuidString: "00000000-0000-0000-0000-000000000000") else {
+            XCTFail("Test UUID생성 실패")
+            return
         }
+        let smallerTimestamp = Timestamp(updatedAt: defaultDate, updatedBy: smallerUUID)
+        let textObject = TextObject(
+            id: UUID(),
+            centerPosition: CGPoint(x: 50, y: 50),
+            size: CGSize(width: 200, height: 200),
+            text: "incoming")
+        let mockRegister = LWWRegister(whiteboardObject: textObject, timestamp: smallerTimestamp)
+
+        // 실행
+        let sut = register.merge(register: mockRegister)
+
+        // 검증
+        XCTAssertEqual(sut, register)
     }
 
+    // 새로 들어온 updatedAt이 더 느릴 때
+    func testMergeWhenIncomingTimestampIsLater() {
+        // 준비
+        let laterDate = defaultDate.addingTimeInterval(10)
+        let laterTimestamp = Timestamp(updatedAt: laterDate, updatedBy: UUID())
+        let textObject = TextObject(
+            id: UUID(),
+            centerPosition: CGPoint(x: 50, y: 50),
+            size: CGSize(width: 200, height: 200),
+            text: "incoming")
+        let mockRegister = LWWRegister(whiteboardObject: textObject, timestamp: laterTimestamp)
+
+        // 실행
+        let sut = register.merge(register: mockRegister)
+
+        // 검증
+        XCTAssertEqual(sut, mockRegister)
+    }
+
+    // updatedAt은 같지만 새로 들어온 UUID가 클 때
+    func testMergeWhenIncomingTimestampHasLargerUUID() {
+        // 준비
+        guard let largerUUID = UUID(uuidString: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF") else {
+            XCTFail("Test UUID생성 실패")
+            return
+        }
+        let largerTimestamp = Timestamp(updatedAt: defaultDate, updatedBy: largerUUID)
+        let textObject = TextObject(
+            id: UUID(),
+            centerPosition: CGPoint(x: 50, y: 50),
+            size: CGSize(width: 200, height: 200),
+            text: "incoming")
+        let mockRegister = LWWRegister(whiteboardObject: textObject, timestamp: largerTimestamp)
+
+        // 실행
+        let sut = register.merge(register: mockRegister)
+
+        // 검증
+        XCTAssertEqual(sut, mockRegister)
+    }
 }


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
화이트보드 오브젝트의 실시간 데이터 일관성을 보장하기 위해 레지스터를 구현 했습니다.


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
화이트보드 오브젝트의 실시간 데이터 일관성을 보장하기 위해서 CRDT의 LWW 알고리즘을 사용했습니다.
해당 알고리즘을 적용한 Register를 구현하여 화이트보드 오브젝트의 데이터가 시간상 이후에 들어온 데이터로 일관성을 갖게 했습니다.

[노션페이지: 실시간 데이터 일관성 보장하기](https://buttoned-package-f84.notion.site/170856db8fa0809ab2fcd5a4dc58ab55?pvs=4)

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
### LWWRegister
- merge()
    - timestamp가 같을 때

    - 새로 들어온 timestamp가 작을때
        - 새로 들어온 updatedAt이 더 빠를 때

        - updatedAt은 같지만 UUID가 작을때
        
    - 새로 들어온 timestamp가 클 때   
        - 새로 들어온 updatedAt이 더 느릴 때
        
        - updatedAt은 같지만 UUID가 클 때


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->


## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #149 
