### PR TITLE
[Refactor] NearbyNetwork 데이터 송수신 기능 리팩터링

### DIFF
--- a/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
+++ b/DataSource/DataSource/Sources/Interface/NearbyNetworkInterface.swift
@@ -50,16 +50,17 @@ public protocol NearbyNetworkInterface {
         connection: RefactoredNetworkConnection,
         myConnectionInfo: RequestedContext) -> Result<Bool, Never>
 
-    /// 연결된 기기들에게 데이터를 송신합니다.
-    /// - Parameter data: 송신할 데이터
-    func send(data: Data)
-
     /// 연결된 기기들에게 파일을 송신합니다.
     /// - Parameters:
     ///   - fileURL: 파일의 URL
     ///   - info: 파일에 대한 정보
     @available(*, deprecated, message: "이 메서드는 network framework로 리팩터링 하면서 사용되지 않을 예정입니다.")
     func send(fileURL: URL, info: DataInformationDTO) async
+
+    /// 연결된 기기들에게 데이터를 송신합니다.
+    /// - Parameter data: 송신할 데이터
+    /// - Returns: 전송 성공 여부
+    func send(data: DataInformationDTO) async -> Bool
 
     /// 특정 기기에게 파일을 전송합니다.
     /// - Parameters:
@@ -71,6 +72,13 @@ public protocol NearbyNetworkInterface {
         fileURL: URL,
         info: DataInformationDTO,
         to connection: NetworkConnection) async
+
+    /// 특정 기기에게 데이터를 전송합니다.
+    /// - Parameters:
+    ///   - data: 송신할 데이터
+    ///   - connection: 전송할 기기 연결 정보
+    /// - Returns: 전송 성공 여부
+    func send(data: DataInformationDTO, to connection: RefactoredNetworkConnection) async -> Bool
 }
 
 public protocol NearbyNetworkConnectionDelegate: AnyObject {

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
@@ -34,7 +34,8 @@ public final class NearbyNetworkBrowser {
     init(serviceType: String) {
         let option = NWProtocolFramer.Options(definition: NearbyNetworkProtocol.definition)
         let parameter = NWParameters.tcp
-        parameter.defaultProtocolStack
+        parameter
+            .defaultProtocolStack
             .applicationProtocols
             .insert(option, at: 0)
         nwBrowser = NWBrowser(

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkService.swift
@@ -126,7 +126,7 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         }
     }
 
-    public func send(fileURL: URL, info: DataSource.DataInformationDTO) async {
+    public func send(fileURL: URL, info: DataInformationDTO) async {
         let infoJsonData = try? encoder.encode(info)
 
         guard
@@ -150,6 +150,10 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         }
     }
 
+    public func send(data: DataInformationDTO) async -> Bool {
+        return true
+    }
+
     public func send(
         fileURL: URL,
         info: DataSource.DataInformationDTO,
@@ -171,6 +175,10 @@ extension NearbyNetworkService: NearbyNetworkInterface {
         } catch {
             self.logger.log(level: .error, "\(peer)에게 file 데이터 전송 실패")
         }
+    }
+
+    public func send(data: DataInformationDTO, to connection: RefactoredNetworkConnection) async -> Bool {
+        return true
     }
 }
 

--- a/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
@@ -239,14 +239,16 @@ extension RefactoredNearbyNetworkService: NearbyNetworkInterface {
     }
 
     public func send(data: DataInformationDTO) async -> Bool {
-        let result: Bool = await withTaskGroup(of: Void.self, returning: Bool.self) { taskGroup in
-            var childResult = true
+        let result: Bool = await withTaskGroup(of: Bool.self, returning: Bool.self) { taskGroup in
             for connection in nearbyNetworkConnections.values {
                 taskGroup.addTask {
-                    childResult = await self.send(data: data, connection: connection)
+                    return await self.send(data: data, connection: connection)
                 }
             }
-            return childResult
+            for await childResult in taskGroup {
+                if !childResult { return false }
+            }
+            return true
         }
         return result
     }

--- a/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
@@ -15,6 +15,8 @@ import OSLog
 public final class RefactoredNearbyNetworkService {
     public var connectionDelegate: NearbyNetworkConnectionDelegate? = nil
     public var foundPeerHandler: ((_ networkConnections: [RefactoredNetworkConnection]) -> Void)?
+    public let refactoredReciptDataPublisher: AnyPublisher<DataInformationDTO, Never>
+    private let refactoredReciptDataSubject: PassthroughSubject<DataInformationDTO, Never>
     private let serviceName: String
     private let serviceType: String
     private let peerID: UUID
@@ -42,6 +44,8 @@ public final class RefactoredNearbyNetworkService {
         nearbyNetworkConnections = [:]
         jsonEncoder = JSONEncoder()
         jsonDecoder = JSONDecoder()
+        refactoredReciptDataSubject = PassthroughSubject<DataInformationDTO, Never>()
+        refactoredReciptDataPublisher = refactoredReciptDataSubject.eraseToAnyPublisher()
         self.serviceName = serviceName
         self.serviceType = serviceType
         nearbyNetworkBrowser.delegate = self
@@ -99,7 +103,42 @@ public final class RefactoredNearbyNetworkService {
     }
 
     private func handleReceivedData(data: Data?, connection: NWConnection) {
-        self.logger.log(level: .error, "\(connection.debugDescription): 데이터 수신")
+        guard
+            let data,
+            let dataDTO = try? jsonDecoder.decode(DataInformationDTO.self, from: data)
+        else { return }
+
+        refactoredReciptDataSubject.send(dataDTO)
+        self.logger.log(level: .debug, "\(connection.debugDescription): 데이터 수신")
+    }
+
+    private func send(data: DataInformationDTO, connection: NWConnection) async -> Bool {
+        typealias Continuation = CheckedContinuation<Bool, Never>
+        var tryCount = 0
+
+        let encodedData = try? jsonEncoder.encode(data)
+        let message = NWProtocolFramer.Message(nearbyNetworkMessageType: .data)
+        let context = NWConnection.ContentContext(identifier: "Data", metadata: [message])
+
+        while tryCount < 3 {
+            let result = await withCheckedContinuation { (continuation: Continuation) in
+                connection.send(
+                    content: encodedData,
+                    contentContext: context,
+                    completion: .contentProcessed({ error in
+                        if let error {
+                            continuation.resume(returning: false)
+                        } else {
+                            continuation.resume(returning: true)
+                        }
+                    }))
+            }
+
+            if result { return true }
+            tryCount += 1
+        }
+
+        return false
     }
 }
 
@@ -192,15 +231,33 @@ extension RefactoredNearbyNetworkService: NearbyNetworkInterface {
     }
 
     public func send(data: Data) {
-
+        // TODO: - will be deprecated
     }
 
     public func send(fileURL: URL, info: DataInformationDTO) async {
         // TODO: - will be deprecated
     }
 
+    public func send(data: DataInformationDTO) async -> Bool {
+        let result: Bool = await withTaskGroup(of: Void.self, returning: Bool.self) { taskGroup in
+            var childResult = true
+            for connection in nearbyNetworkConnections.values {
+                taskGroup.addTask {
+                    childResult = await self.send(data: data, connection: connection)
+                }
+            }
+            return childResult
+        }
+        return result
+    }
+
     public func send(fileURL: URL, info: DataInformationDTO, to connection: NetworkConnection) async {
         // TODO: - will be deprecated
+    }
+
+    public func send(data: DataInformationDTO, to connection: RefactoredNetworkConnection) async -> Bool {
+        guard let connection = nearbyNetworkConnections[connection] else { return false }
+        return await send(data: data, connection: connection)
     }
 }
 


### PR DESCRIPTION
## 🌁 Background
MPC 프레임워크를 Network 프레임 워크로 교체하며 데이터 송수신 기능을 리팩터링 하였습니다.

## 👩‍💻 Contents
- 데이터 송신
- 데이터 수신

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

데이터 송신 실패 시 반복문을 통해 3회까지 재전송하도록 하였습니다.      
```swift
private func send(data: DataInformationDTO, connection: NWConnection) async -> Bool {
    typealias Continuation = CheckedContinuation<Bool, Never>
    var tryCount = 0

    let encodedData = try? jsonEncoder.encode(data)
    let message = NWProtocolFramer.Message(nearbyNetworkMessageType: .data)
    let context = NWConnection.ContentContext(identifier: "Data", metadata: [message])

    while tryCount < 3 {
        let result = await withCheckedContinuation { (continuation: Continuation) in
            connection.send(
                content: encodedData,
                contentContext: context,
                completion: .contentProcessed({ error in
                    if let error {
                        continuation.resume(returning: false)
                    } else {
                        continuation.resume(returning: true)
                    }
                }))
        }

        if result { return true }
        tryCount += 1
    }

    return false
}
```

## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #146 
- close #147 
