### PR TITLE
[Fix] Network 서비스에서 사용할 NWParameter 옵션 변경

### DIFF
--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkBrowser.swift
@@ -31,16 +31,10 @@ public final class NearbyNetworkBrowser {
     }
     weak var delegate: NearbyNetworkBrowserDelegate?
 
-    init(serviceType: String) {
-        let option = NWProtocolFramer.Options(definition: NearbyNetworkProtocol.definition)
-        let parameter = NWParameters.tcp
-        parameter
-            .defaultProtocolStack
-            .applicationProtocols
-            .insert(option, at: 0)
+    init(serviceType: String, networkParameter: NWParameters) {
         nwBrowser = NWBrowser(
             for: .bonjourWithTXTRecord(type: serviceType, domain: nil),
-            using: parameter)
+            using: networkParameter)
         self.browserQueue = DispatchQueue.global()
         self.serviceType = serviceType
         self.logger = Logger()

--- a/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkListener.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/NearbyNetworkListener.swift
@@ -38,14 +38,10 @@ public final class NearbyNetworkListener {
     init(
         peerID: UUID,
         serviceName: String,
-        serviceType: String
+        serviceType: String,
+        networkParameter: NWParameters
     ) {
-        let option = NWProtocolFramer.Options(definition: NearbyNetworkProtocol.definition)
-        let parameter = NWParameters.tcp
-        parameter.defaultProtocolStack
-            .applicationProtocols
-            .insert(option, at: 0)
-        nwListener = try? NWListener(using: parameter)
+        nwListener = try? NWListener(using: networkParameter)
         listenerQueue = DispatchQueue.global()
         self.peerID = peerID
         self.serviceName = serviceName

--- a/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
+++ b/NearbyNetwork/NearbyNetwork/Sources/RefactoredNearbyNetworkService.swift
@@ -20,6 +20,7 @@ public final class RefactoredNearbyNetworkService {
     private let serviceName: String
     private let serviceType: String
     private let peerID: UUID
+    private let nearbyNetworkParameter: NWParameters
     private let nearbyNetworkListener: NearbyNetworkListener
     private let nearbyNetworkBrowser: NearbyNetworkBrowser
     private let nearbyNetworkServiceQueue: DispatchQueue
@@ -36,11 +37,31 @@ public final class RefactoredNearbyNetworkService {
         peerID = myPeerID
         nearbyNetworkServiceQueue = DispatchQueue.global()
         logger = Logger()
+
+        let option = NWProtocolFramer.Options(definition: NearbyNetworkProtocol.definition)
+        let tcpOption = NWProtocolTCP.Options()
+        tcpOption.enableKeepalive = true
+        tcpOption.keepaliveIdle = 5
+        tcpOption.keepaliveCount = 2
+        tcpOption.keepaliveInterval = 3
+        tcpOption.connectionTimeout = 5
+        tcpOption.connectionDropTime = 5
+        tcpOption.persistTimeout = 5
+        nearbyNetworkParameter = NWParameters(tls: nil, tcp: tcpOption)
+
+        nearbyNetworkParameter.defaultProtocolStack
+            .applicationProtocols
+            .insert(option, at: 0)
+        nearbyNetworkParameter.includePeerToPeer = true
+
         nearbyNetworkListener = NearbyNetworkListener(
             peerID: peerID,
             serviceName: serviceName,
-            serviceType: serviceType)
-        nearbyNetworkBrowser = NearbyNetworkBrowser(serviceType: serviceType)
+            serviceType: serviceType,
+            networkParameter: nearbyNetworkParameter)
+        nearbyNetworkBrowser = NearbyNetworkBrowser(
+            serviceType: serviceType,
+            networkParameter: nearbyNetworkParameter)
         nearbyNetworkConnections = [:]
         jsonEncoder = JSONEncoder()
         jsonDecoder = JSONDecoder()


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
리뷰 노트 참고 


## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
- Network 서비스에서 사용할 NWParameter 옵션 변경


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
기존에는 NWParameter에서 클래스 변수로 제공하는 tcp를 이용하여 네트워크 서비스를 구축했습니다. 하지만 아래와 같은 문제로 tcp옵션을 커스텀해야 할 필요성을 느꼈습니다.

1. NWParameter.tcp의 connectionTimeout 시간은 기본적으로 0으로 설정되어 있습니다.      
이 connectionTimeout은 TCP가 establish하여 connection을 연결하는데 걸리는 시간을 제한합니다. 
한 가지 유의할 점은, 이 connectionTimeout이 0이면 연결 대기를 제한된 시간동안 진행하는 것이 아닌 무기한 대기한다는 점입니다. 따라서 저희는 임의로 5초로 설정하였습니다. (범용적으로 많이 사용하는 connectionTime시간에 대해서는 잘 알지 못해서.. 적절한 설정값이 있으면 추후 수정하겠습니다.)


2. 실기기를 이용한 테스트 중 종종 앱을 강제 종료하면 상대방 기기에서 연결이 정상적으로 끊어지지 않는 문제가 있었습니다.      
TCP는 연결 기반의 전송 계층 프로토콜입니다. 따라서 연결을 끊을 때도 handshake를 통해 연결을 종료하게 되는데요, 이 연결을 끊기 위한 handshake가 정상적으로 동작하지 않아 위와 같은 문제가 일어나는 것이라 추측했습니다. (패킷 로스 또는 handshake가 정상적 수행 안됨).     
이를 해결하기 위해 Keep-Alive가 필요했습니다. Keep-Alive는 장시간 연결이 유휴 상태일 때도 연결을 유지(persistence connection을 유지)하기 위한 옵션입니다. Keep-Alive의 간단한 동작 방식은 아래와 같습니다.
- A, B가 연결이 되어 있다가 B가 비정상적으로 연결을 끊어버렸다고 가정하겠습니다. 이때 A의 tcp 소켓은 여전히 열려있을 것입니다.
- 장기간 B와 교류가 없다면, A는 B에게 keep-alive 패킷을 전송하고, 이에 대한 ack를 받지 못하면 연결을 종료합니다.       

NWParameter.tcp는 기본적으로 Keep-Alive 기능이 꺼져있어서 커스텀 NWProtocolTCP의 option에서 해당 기능을 enable하게 수정했습니다.

